### PR TITLE
feat: production-grade first-turn tool router v0.2 RC1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: tests
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install -e '.[dev,classifier]'
+      - run: python -m py_compile *.py tests/*.py benchmarks/*.py
+      - run: python -m pytest
+      - run: python benchmarks/run.py
+      - run: python -m build

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.venv/
+build/
+dist/
+dist-*/
+*.egg-info/
+runs/
 .DS_Store
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -1,207 +1,123 @@
 # Hermes Tool Router
 
-A standalone Hermes Agent plugin that reduces prompt token overhead by selecting only the toolsets a turn is likely to need before Hermes builds the prompt and tool schema payload.
+Experimental standalone Hermes Agent plugin for reducing first-turn tool-schema overhead without repeatedly changing the tool prefix later in the conversation.
 
-It keeps a small recovery tool, `request_toolset`, available so the model can ask for a missing toolset during the turn instead of silently failing.
+> Test on a separate Hermes profile first. Do not install an experimental router directly on a primary profile.
 
-> **Proof-of-concept warning:** this plugin is experimental. Do not enable it first on your primary Hermes profile. Create a separate test profile, or enable it only on an alternate profile you can reset easily, then move it to daily use only after you have tested your toolset mix and routing behavior.
+## v0.2 design
 
-![Hermes Tool Router flow](docs/tool-router-flow.svg)
+- **First-turn routing:** deterministic intent classification narrows the live tool surface before the first provider request through stock Hermes hooks.
+- **Session-sticky surface:** later turns reuse the initial surface instead of reclassifying and shrinking it.
+- **Monotonic recovery:** requested toolsets are added permanently for the session.
+- **Fail open:** uncertainty, invalid classifier output, missing confidence, timeout, registry mismatch, or unsupported runtime keeps the full tool surface.
+- **Optional classifier:** external model routing is disabled by default. Deterministic misses fall back immediately with no network call.
+- **Dynamic recovery:** `request_toolset` is generated from the live toolset registry and can request multiple toolsets.
 
-For a larger visual walkthrough, open [`docs/how-it-works.html`](docs/how-it-works.html).
+## Critical compatibility fact
 
-## What it does
+First-turn token savings work through either an early Hermes surface hook or the stock `pre_llm_call` compatibility path. In current Hermes, `pre_llm_call` runs after the initial preflight estimate but before the actual provider request is assembled and before the loop's request-pressure estimate; mutating `agent.tools` there still reduces the transmitted tool schemas. The tradeoff is that the plugin must recover the live agent through compatibility logic unless Hermes passes it explicitly.
 
-- Runs before turn-context construction through Hermes' `pre_turn_context_build` hook.
-- Predicts needed toolsets with deterministic rules first. If no deterministic rule is confident, it can call a small, fast router model to classify the turn.
-- Mutates the live agent tool surface for the current turn only.
-- Falls back open to the full toolset on uncertainty, errors, long messages, unavailable router credentials, or unsupported hook versions.
-- Provides `request_toolset(toolset, reason)` as an escape hatch when the model needs a filtered-out toolset.
-- Keeps `pre_llm_call` as a compatibility fallback for older Hermes builds.
-
-## Requirements
-
-- Hermes Agent with plugin support.
-- Best with Hermes builds that expose the `pre_turn_context_build` hook.
-- Python package `pyyaml` available in the Hermes environment.
-- For deterministic-only routing: no model API key is required.
-- For full routing behavior on ambiguous/non-obvious requests: a small OpenAI-compatible router model is required, plus `openai` and either `DEEPSEEK_API_KEY` or `OPENROUTER_API_KEY`.
-
-Deterministic routing works without external API keys, but it only covers obvious intent patterns. Without a router model, uncertain turns fail open to the full toolset.
-
-## Dependencies
-
-Minimal runtime:
+Run diagnostics:
 
 ```bash
-pip install -r requirements.txt
+python diagnostics.py
 ```
 
-`pyyaml` is required for configuration loading. `openai` is only needed if you enable LLM-based router calls through DeepSeek or OpenRouter.
+Exit code `0` means a routing path is available before the provider request. Exit code `2` means the current runtime must not claim first-turn savings. The report separately states whether routing happens before the initial preflight estimate.
 
-Important: the router model should be small and low-latency. It runs before the main model call on turns that deterministic rules cannot classify, so using a large/slow model can erase the token savings with added delay.
+Automatic execution recovery uses Hermes's generic `tool_request` middleware. When the model emits a registry-known tool that was pruned, the middleware expands its owning toolset before normal validation and dispatch, then the original call continues through ordinary requirement checks and approvals. `request_toolset` remains the visible fallback.
 
-## Installation
+### No Hermes core patch required
 
-Recommended setup: install and test in a separate Hermes profile.
+The tested implementation is plugin-only. Current Hermes already provides both extension points needed for provider-request reduction and automatic tool recovery. There is no router edit in Hermes core and no router entry in `apply-patches.sh`. An optional earlier hook could reduce internal preflight work, but it is not required for the measured request savings or successful tool execution.
+
+See [docs/compatibility.md](docs/compatibility.md).
+
+## Install on a test profile
 
 ```bash
 hermes profile create router-test --clone
-```
-
-Then install the plugin for that profile's Hermes home. If your profile uses the standard layout, that means:
-
-```bash
 mkdir -p ~/.hermes/profiles/router-test/plugins
-cp -R hermes-token-router-public ~/.hermes/profiles/router-test/plugins/hermes-token-router
+cp -R . ~/.hermes/profiles/router-test/plugins/hermes-token-router
 ```
 
-Enable the plugin in the test profile config, not your main profile, until you are comfortable with its behavior:
-
-```yaml
-plugins:
-  enabled:
-    - hermes-token-router
-```
-
-Run a test session with:
-
-```bash
-hermes --profile router-test chat
-```
-
-Only after testing should you copy the plugin into your main `~/.hermes/plugins/` directory or enable it globally.
-
-Clone or copy this repository into your Hermes plugins folder under the plugin name `hermes-token-router`:
-
-```bash
-mkdir -p ~/.hermes/plugins
-cp -R hermes-token-router-public ~/.hermes/plugins/hermes-token-router
-```
-
-Enable it in your Hermes config:
-
-```yaml
-plugins:
-  enabled:
-    - hermes-token-router
-```
-
-Then edit the plugin's `config.yaml` and enable only the test profile at first.
-
-Example test-profile setup:
-
-```yaml
-global:
-  enabled: false
-
-profiles:
-  router-test:
-    enabled: true
-    floor_toolsets: [terminal, file, web]
-    deterministic_rules_enabled: true
-    long_message_decline_chars: 12000
-    router_provider: deepseek
-    router_model: deepseek-chat
-```
-
-Restart Hermes or start a fresh session after changing plugin configuration.
+Enable the plugin in the test profile, then set `profiles.router-test.enabled: true` in the plugin's `config.yaml`. Start a fresh session after configuration changes.
 
 ## Configuration
 
+The safe default is disabled. Important v2 settings:
+
 ```yaml
 global:
   enabled: false
-  floor_toolsets: [terminal, file, web]
+  routing_scope: first_turn
+  expansion_mode: monotonic
+  shrink_mid_session: false
+  floor_toolsets: []
   deterministic_rules_enabled: true
-  confidence_threshold: 0.0
-  long_message_decline_chars: 12000
-  short_message_bypass_chars: 0
-  router_provider: deepseek
-  router_model: deepseek-chat
-
-profiles:
-  router-test:
-    enabled: true
+  confidence_threshold: 0.90
+  fail_open: true
+  classifier:
+    enabled: false
 ```
 
-Key settings:
+The classifier remains opt-in because adding a network request before every uncertain main-model call can erase latency gains. When disabled, unresolved deterministic requests keep all tools. Direct DeepSeek is the default hosted classifier; OpenRouter is used only when explicitly selected. A local OpenAI-compatible endpoint can be configured as:
 
-- `enabled`: opt-in switch. Leave global disabled unless you intentionally want the router everywhere.
-- `floor_toolsets`: toolsets always retained after routing. Use `[]` for aggressive reduction.
-- `deterministic_rules_enabled`: fast regex-based routes for common intents.
-- `long_message_decline_chars`: bypass routing for complex long turns.
-- `short_message_bypass_chars`: optional bypass for very short messages.
-- `router_provider`: `deepseek` or `openrouter`.
-- `router_model`: model name for the selected provider.
+```yaml
+classifier:
+  enabled: true
+  provider: custom
+  model: router-local
+  base_url: http://127.0.0.1:1234/v1
+  api_key_env: null  # or an environment-variable name when authentication is required
+```
 
-## Provider notes
-
-Supported direct router providers:
-
-- `deepseek` via `DEEPSEEK_API_KEY`, default sample `deepseek-chat`.
-- `openrouter` via `OPENROUTER_API_KEY`, for example `meta-llama/llama-3.1-8b-instruct`.
-
-`openai-codex` is intentionally disabled in the plugin because Codex uses a Responses API transport, not standard Chat Completions.
-
-Recommended router model profile:
-
-- Small instruction model, roughly 7B-12B class or equivalent fast hosted model.
-- Strong JSON-following behavior.
-- Low latency, ideally sub-second for a short classification prompt.
-- Cheap enough to run on many turns.
-
-Examples:
-
-- `deepseek-chat` through DeepSeek, simple default and broadly available.
-- `meta-llama/llama-3.1-8b-instruct` through OpenRouter or another fast OpenAI-compatible provider.
-- A local OpenAI-compatible endpoint can be added by extending `_get_router_client()`.
-
-## Privacy and data egress
-
-When deterministic rules are enough, no user prompt text leaves the local Hermes process.
-
-If deterministic rules cannot classify the turn and router model credentials are available, the plugin sends up to the first 1,500 characters of the user message plus the available toolset list to the configured router provider. For sensitive environments, either:
-
-- keep `deterministic_rules_enabled: true` and avoid configuring router provider credentials, so uncertain turns fall back to the full local toolset;
-- set a high `confidence_threshold` and conservative `floor_toolsets`; or
-- disable the plugin for profiles that handle sensitive prompts.
-
-## Safety model
-
-The plugin is designed to fail open:
-
-- Config disabled: no changes.
-- No router credentials: full toolset fallback unless deterministic rules already made a confident route.
-- Router timeout or invalid JSON: full toolset fallback.
-- Unknown toolset: full toolset fallback.
-- Missing tool detected after narrowing: attempts to expand the owning toolset.
-
-The only intentionally aggressive mode is `floor_toolsets: []`, which can leave only `request_toolset` for plain-answer turns.
-
-## Development and tests
-
-Run the smoke tests from the repository root:
+## Development
 
 ```bash
-python3 -m py_compile *.py tests/*.py
-python3 tests/smoke_hardening.py
-python3 -m pytest tests -q
+python3 -m py_compile *.py tests/*.py benchmarks/*.py
+python3 -m pytest
+python3 benchmarks/run.py
+python3 -m build
 ```
 
-The tests use a fake Hermes tool registry and do not require live API credentials.
+The committed 500-record corpus is a synthetic regression suite. It validates deterministic contracts; it does not replace live full-tools-versus-routed E2E testing.
 
-## Repository contents
+## Current measured schema reduction
 
-- `__init__.py` — plugin registration, hooks, and recovery handler.
-- `config.py` — config loading and profile resolution.
-- `policy.py` — deterministic and LLM-based toolset prediction.
-- `tools.py` — registry resolution, filtering, expansion, and recovery tool schema.
-- `state.py` — agent-scoped router state.
-- `config.yaml` — safe disabled-by-default sample config.
-- `tests/` — smoke tests for routing and recovery.
-- `docs/pre_turn_context_build_hook.md` — design notes for the required core hook.
+Against the live 39-tool Hermes registry, Hermes's own rough request estimator measured:
+
+- `web`: 18,627 → 490 tokens (**97.37% reduction**)
+- `file,terminal`: 18,627 → 3,207 tokens (**82.78% reduction**)
+- `browser,web`: 18,627 → 3,364 tokens (**81.94% reduction**)
+
+See [`docs/baselines/v0.2-rc1.md`](docs/baselines/v0.2-rc1.md) for commands and caveats. These are estimator results, not provider billing receipts.
+
+## Live Edith A/B validation
+
+A paired full-tools-versus-routed evaluation using `openai/gpt-5.4-mini` produced:
+
+- **10/10** safe-core cases passed;
+- **100%** required-toolset recall;
+- **100%** exact route accuracy;
+- **100%** tool-call success and answer accuracy;
+- **61.60%** average reduction in actual first-provider-request tokens across the no-tool, terminal, and web pairs;
+- **94.239983** autoresearch score.
+
+The run used stock Hermes hooks and no core patch. See [`docs/live-evaluation-v0.2-rc1.md`](docs/live-evaluation-v0.2-rc1.md) for the corpus, methodology, commands, raw token counts, and scope limitations.
+
+## Current release gates
+
+A stable release must demonstrate:
+
+- at least 70% median first-turn schema-token reduction;
+- at least 99.5% required-toolset recall and 100% critical-class recall;
+- no unrecovered registered-tool failures in E2E testing;
+- no task-success regression against the full-tool baseline;
+- cache-stable serialized tool schemas after routing or the last expansion.
+
+No quantitative production claim should be made until a versioned live validation report satisfies those gates.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT.

--- a/__init__.py
+++ b/__init__.py
@@ -18,8 +18,10 @@ try:
         DEFAULT_ROUTER_PROVIDER,
         PLUGIN_NAME,
         _get_profile_config,
+        _get_classifier_connection,
         _get_router_model,
         _get_router_provider,
+        _is_classifier_enabled,
         _is_router_active,
         _load_config,
     )
@@ -39,6 +41,7 @@ try:
     from .state import (
         ROUTER_STATE_ATTR,
         RouterState,
+        _drop_agent_ref,
         _get_agent_from_stack,
         _get_agent_ref,
         _get_router_state,
@@ -49,6 +52,7 @@ try:
         RECOVERY_TOOL_SCHEMA,
         RECOVERY_TOOLSET,
         RECOVERY_TOOLSET_CHOICES,
+        build_recovery_tool_schema,
         _apply_predicted_tools,
         _cache_full_toolset,
         _detect_missing_toolset,
@@ -70,8 +74,10 @@ except ImportError:  # pragma: no cover - direct loader fallback
         DEFAULT_ROUTER_PROVIDER,
         PLUGIN_NAME,
         _get_profile_config,
+        _get_classifier_connection,
         _get_router_model,
         _get_router_provider,
+        _is_classifier_enabled,
         _is_router_active,
         _load_config,
     )
@@ -91,6 +97,7 @@ except ImportError:  # pragma: no cover - direct loader fallback
     from state import (
         ROUTER_STATE_ATTR,
         RouterState,
+        _drop_agent_ref,
         _get_agent_from_stack,
         _get_agent_ref,
         _get_router_state,
@@ -101,6 +108,7 @@ except ImportError:  # pragma: no cover - direct loader fallback
         RECOVERY_TOOL_SCHEMA,
         RECOVERY_TOOLSET,
         RECOVERY_TOOLSET_CHOICES,
+        build_recovery_tool_schema,
         _apply_predicted_tools,
         _cache_full_toolset,
         _detect_missing_toolset,
@@ -154,21 +162,30 @@ def _route_tool_surface(source: str, agent: Any = None, **kwargs: Any) -> Option
     if not user_message:
         return None
 
+    session_id = str(kwargs.get("session_id") or getattr(agent, "session_id", "") or "")
     if agent is not None:
-        _store_agent_ref(agent)
+        _store_agent_ref(agent, session_id)
     else:
-        agent = _get_agent_ref()
-        if agent is None:
-            agent = _get_agent_from_stack()
-            if agent is not None:
-                _store_agent_ref(agent)
-                logger.info("%s: acquired agent reference via stack introspection", PLUGIN_NAME)
-            else:
-                logger.warning("%s: no agent reference; full set fallback", PLUGIN_NAME)
-                return None
+        # The current hook stack is authoritative; a cached session mapping can
+        # be stale after resets or test/profile reloads.
+        agent = _get_agent_from_stack() or _get_agent_ref(session_id)
+        if agent is not None:
+            session_id = session_id or str(getattr(agent, "session_id", "") or "")
+            _store_agent_ref(agent, session_id)
+            logger.info("%s: acquired agent reference for compatibility hook", PLUGIN_NAME)
+        else:
+            logger.warning("%s: no agent reference; full set fallback", PLUGIN_NAME)
+            return None
 
     turn_id = kwargs.get("turn_id") or getattr(agent, "_current_turn_id", "") or ""
     state = _get_router_state(agent)
+
+    # Production policy: classify only the initial tool surface. Later turns
+    # reuse the session-sticky surface so tool schemas remain cache-stable.
+    if state.initial_route_applied and source == "pre_turn_context_build":
+        if turn_id:
+            _mark_turn_routed(agent, state, turn_id, "sticky_surface")
+        return None
 
     if source != "pre_turn_context_build" and _was_turn_routed(agent, state, turn_id):
         logger.debug("%s: skipping duplicate late pre_llm_call for early-routed turn", PLUGIN_NAME)
@@ -190,6 +207,7 @@ def _route_tool_surface(source: str, agent: Any = None, **kwargs: Any) -> Option
     confidence_threshold = float(profile_cfg.get("confidence_threshold", 0.0))
     router_model = _get_router_model(profile_cfg)
     router_provider = _get_router_provider(profile_cfg)
+    classifier_base_url, classifier_api_key_env = _get_classifier_connection(profile_cfg)
     state.router_model = router_model
 
     profile_name = profile_cfg.get("_profile_name", "unknown")
@@ -258,24 +276,31 @@ def _route_tool_surface(source: str, agent: Any = None, **kwargs: Any) -> Option
             sorted(predicted),
         )
     else:
-        # Predict toolsets via router model
-        try:
-            predicted = _predict_toolsets_via_llm(
-                user_message,
-                available,
-                router_model,
-                confidence_threshold,
-                router_provider,
-            )
-        except Exception as exc:
-            logger.warning(
-                "%s: prediction failed: %s; full set fallback",
-                PLUGIN_NAME, exc,
-            )
-            _restore_full_tools(agent)
-            state.active = False
-            state.predicted_toolsets = None
-            return complete()
+        # The external classifier is opt-in. An unresolved deterministic route
+        # fails open immediately when it is disabled—zero network latency.
+        if not _is_classifier_enabled(profile_cfg):
+            predicted = None
+        else:
+            try:
+                predicted = _predict_toolsets_via_llm(
+                    user_message,
+                    available,
+                    router_model,
+                    confidence_threshold,
+                    router_provider,
+                    max(0.05, float(profile_cfg.get("router_hard_timeout_ms", 1200)) / 1000.0),
+                    classifier_base_url,
+                    classifier_api_key_env,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "%s: prediction failed: %s; full set fallback",
+                    PLUGIN_NAME, exc,
+                )
+                _restore_full_tools(agent)
+                state.active = False
+                state.predicted_toolsets = None
+                return complete()
 
     if predicted is None:
         # Bypass; keep full toolsets
@@ -310,9 +335,10 @@ def _route_tool_surface(source: str, agent: Any = None, **kwargs: Any) -> Option
         state.predicted_toolsets = None
         return complete()
 
-    # Store agent-scoped state for post_tool_call/request_toolset
+    # Store agent-scoped state for post_tool_call/request_toolset.
     state.active = True
     state.predicted_toolsets = predicted
+    state.set_initial_surface(set(predicted) | floor_toolsets)
     state._fallback_triggered = False
     state._retry_pending = False
 
@@ -330,64 +356,124 @@ def _route_tool_surface(source: str, agent: Any = None, **kwargs: Any) -> Option
 def request_toolset_handler(args: Dict[str, Any], **kwargs: Any) -> str:
     """Expand the live agent with one requested toolset."""
     requested_toolset = str(args.get("toolset") or args.get("toolset_name") or "").strip().lower()
+    raw_toolsets = args.get("toolsets") or []
+    requested_toolsets = {
+        str(name).strip().lower() for name in raw_toolsets if str(name).strip()
+    } if isinstance(raw_toolsets, list) else set()
+    if requested_toolset:
+        requested_toolsets.add(requested_toolset)
     requested_tool = str(args.get("tool_name") or "").strip()
     reason = str(args.get("reason") or "").strip()[:200]
 
     try:
         from tools.registry import registry
         available = set(registry.get_registered_toolset_names())
-        if requested_tool and not requested_toolset:
-            requested_toolset = _infer_toolset_from_tool(requested_tool, registry) or ""
-        alias_target = registry.get_toolset_alias_target(requested_toolset) if requested_toolset else None
-        if alias_target:
-            requested_toolset = alias_target
+        if requested_tool:
+            owner = _infer_toolset_from_tool(requested_tool, registry)
+            if owner:
+                requested_toolsets.add(owner)
+        requested_toolsets = {
+            registry.get_toolset_alias_target(name) or name for name in requested_toolsets
+        }
     except Exception:
         available = set()
 
-    if not requested_toolset:
+    if not requested_toolsets:
         return json.dumps({
             "ok": False,
-            "error": "toolset or resolvable tool_name is required",
-            "requested_toolset": requested_toolset,
+            "error": "toolsets or resolvable tool_name is required",
+            "requested_toolsets": [],
             "requested_tool": requested_tool,
         })
 
-    if available and requested_toolset not in available:
-        suggestions = difflib.get_close_matches(requested_toolset, sorted(available), n=5)
+    unknown = requested_toolsets - available if available else set()
+    if unknown:
+        bad = sorted(unknown)[0]
+        suggestions = difflib.get_close_matches(bad, sorted(available), n=5)
         return json.dumps({
             "ok": False,
-            "error": f"unknown toolset: {requested_toolset}",
-            "requested_toolset": requested_toolset,
+            "error": f"unknown toolset: {bad}",
+            "requested_toolsets": sorted(requested_toolsets),
             "requested_tool": requested_tool,
             "suggestions": suggestions,
             "available_toolsets": sorted(available),
         })
 
-    agent = _get_agent_ref() or _get_agent_from_stack()
+    session_id = str(kwargs.get("session_id") or "")
+    agent = _get_agent_ref(session_id) or _get_agent_from_stack()
     if agent is None:
         return json.dumps({
             "ok": False,
             "error": "no live agent reference",
-            "requested_toolset": requested_toolset,
+            "requested_toolsets": sorted(requested_toolsets),
             "requested_tool": requested_tool,
         })
 
     state = _get_router_state(agent)
     if state._full_tool_defs is None:
         _cache_full_toolset(agent)
-    _expand_toolset(agent, requested_toolset)
+    for toolset_name in sorted(requested_toolsets):
+        _expand_toolset(agent, toolset_name)
     _ensure_recovery_tool(agent)
     state.active = True
     state._retry_pending = False
 
     enabled_tools = sorted(getattr(agent, "valid_tool_names", set()) or set())
-    return json.dumps({
+    response = {
         "ok": True,
-        "toolset": requested_toolset,
+        "toolsets": sorted(requested_toolsets),
         "requested_tool": requested_tool,
         "reason": reason,
         "enabled_tools": enabled_tools,
-    })
+    }
+    if len(requested_toolsets) == 1:
+        response["toolset"] = next(iter(requested_toolsets))
+    return json.dumps(response)
+
+
+def tool_request_middleware(**kwargs: Any) -> Optional[Dict[str, Any]]:
+    """Expand a registry-known pruned tool before Hermes validates/dispatches it.
+
+    Hermes applies ``tool_request`` middleware before it passes the current
+    ``valid_tool_names`` set into normal dispatch. Updating the agent here lets
+    the original call continue through ordinary check_fn, approvals, and
+    execution without an invalid-tool round trip.
+    """
+    session_id = str(kwargs.get("session_id") or "")
+    tool_name = str(kwargs.get("tool_name") or "").strip()
+    args = kwargs.get("args")
+    if not tool_name or not isinstance(args, dict):
+        return None
+    agent = _get_agent_ref(session_id)
+    if agent is None:
+        return None
+    state = _get_router_state(agent)
+    if not state.active or tool_name in (getattr(agent, "valid_tool_names", set()) or set()):
+        return None
+    try:
+        from tools.registry import registry
+        toolset_name = _infer_toolset_from_tool(tool_name, registry)
+    except Exception:
+        toolset_name = None
+    if not toolset_name:
+        return None
+    _expand_toolset(agent, toolset_name)
+    if tool_name not in (getattr(agent, "valid_tool_names", set()) or set()):
+        return None
+    logger.info(
+        "%s: middleware recovery added toolset=%s for tool=%s session=%s",
+        PLUGIN_NAME,
+        toolset_name,
+        tool_name,
+        session_id,
+    )
+    return {"args": dict(args), "router_recovered": toolset_name}
+
+
+def on_session_end(**kwargs: Any) -> None:
+    session_id = str(kwargs.get("session_id") or "")
+    if session_id:
+        _drop_agent_ref(session_id)
 
 
 def register(ctx) -> None:
@@ -400,32 +486,36 @@ def register(ctx) -> None:
     """
 
     try:
-        ctx.register_hook("pre_turn_context_build", pre_turn_context_build)
+        from hermes_cli.plugins import VALID_HOOKS
+        if "pre_turn_context_build" in VALID_HOOKS:
+            ctx.register_hook("pre_turn_context_build", pre_turn_context_build)
     except Exception as exc:
-        logger.warning(
-            "%s: pre_turn_context_build hook unavailable; using pre_llm_call fallback: %s",
-            PLUGIN_NAME,
-            exc,
-        )
+        logger.debug("%s: early routing hook unavailable: %s", PLUGIN_NAME, exc)
 
     ctx.register_hook("pre_llm_call", pre_llm_call)
     ctx.register_hook("post_tool_call", post_tool_call)
+    ctx.register_hook("on_session_end", on_session_end)
+    try:
+        ctx.register_middleware("tool_request", tool_request_middleware)
+    except Exception as exc:
+        logger.warning("%s: tool_request middleware unavailable: %s", PLUGIN_NAME, exc)
 
     try:
         from tools.registry import registry
+        recovery_schema = build_recovery_tool_schema(set(registry.get_registered_toolset_names()))
         registry.register(
             name=RECOVERY_TOOL_NAME,
             toolset=RECOVERY_TOOLSET,
-            schema=RECOVERY_TOOL_SCHEMA,
+            schema=recovery_schema,
             handler=request_toolset_handler,
-            description=RECOVERY_TOOL_SCHEMA["description"],
+            description=recovery_schema["description"],
             emoji="",
         )
     except Exception as exc:
         logger.warning("%s: failed to register recovery tool: %s", PLUGIN_NAME, exc)
 
     logger.info(
-        "%s plugin registered (hooks: pre_turn_context_build, pre_llm_call, post_tool_call; tool: request_toolset)",
+        "%s plugin registered (routing: pre_llm_call compatibility; middleware: tool_request; tool: request_toolset)",
         PLUGIN_NAME,
     )
 
@@ -453,7 +543,8 @@ def post_tool_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
     Returns None (observer hook, no return value consumed by caller).
     """
 
-    agent = _get_agent_ref() or _get_agent_from_stack()
+    session_id = str(kwargs.get("session_id") or "")
+    agent = _get_agent_ref(session_id) or _get_agent_from_stack()
     if agent is None:
         return None
     state = _get_router_state(agent)
@@ -487,21 +578,6 @@ def post_tool_call(**kwargs: Any) -> Optional[Dict[str, Any]]:
         # Find which toolset this tool belongs to
         from tools.registry import registry
         missing_toolset = _infer_toolset_from_tool(tool_name, registry)
-
-        if missing_toolset is None:
-            logger.debug(
-                "%s: could not determine toolset for '%s' — checking by name prefix",
-                PLUGIN_NAME, tool_name,
-            )
-            # Fall back: add all tools for the inferred toolset
-            try:
-                from tools.registry import registry
-                for entry in registry._snapshot_entries():
-                    if entry.name == tool_name:
-                        missing_toolset = entry.toolset
-                        break
-            except Exception:
-                pass
 
         if missing_toolset is None:
             logger.debug(

--- a/autoresearch/router_live_eval.json
+++ b/autoresearch/router_live_eval.json
@@ -1,0 +1,21 @@
+{
+  "repo_path": ".",
+  "proposal_command": ["/usr/bin/true"],
+  "evaluator_command": [
+    ".venv/bin/python",
+    "scripts/live_router_evaluator.py",
+    "--output",
+    "runs/autoresearch_live_router_eval.json"
+  ],
+  "max_trials": 1,
+  "max_seconds": 1800,
+  "stop_after_no_improve": 1,
+  "min_improvement": 0.0,
+  "keep_on_improve": true,
+  "revert_on_no_improve": false,
+  "revert_on_failure": false,
+  "allowlist_relative_paths": ["intent.py", "policy.py", "config.py", "tests", "benchmarks", "scripts", "runs"],
+  "tsv_log_path": "runs/autoresearch_experiments.tsv",
+  "jsonl_log_path": "runs/autoresearch_experiments.jsonl",
+  "command_timeout_seconds": 1700
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,11 @@
+# Router benchmark corpus
+
+`prompts.jsonl` is a 500-record synthetic deterministic regression corpus. It verifies stable routing contracts and critical-class recall; it is not, by itself, evidence of real-world task parity.
+
+Run:
+
+```bash
+python benchmarks/run.py
+```
+
+Release claims additionally require live Hermes full-tools-versus-routed E2E testing, provider token accounting, cache-read measurements, and a representative human-curated/adversarial corpus.

--- a/benchmarks/live_cases.json
+++ b/benchmarks/live_cases.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "answer_only",
+    "prompt": "What is photosynthesis? Answer accurately in one sentence.",
+    "expected_toolsets": [],
+    "expected_tools": [],
+    "must_contain": ["oxygen"]
+  },
+  {
+    "id": "terminal",
+    "prompt": "Use the terminal to run exactly this command without adding ./ or changing the path: `{{HERMES_PYTHON}} --version`. Return the exact output.",
+    "expected_toolsets": ["terminal"],
+    "expected_tools": ["terminal"],
+    "must_contain": ["Python 3.11.14"]
+  },
+  {
+    "id": "file",
+    "prompt": "Read /tmp/router-edith-probe.txt and return its exact contents only.",
+    "expected_toolsets": ["file"],
+    "expected_tools": ["read_file"],
+    "must_contain": ["EDITH_ROUTER_PROBE_OK"]
+  },
+  {
+    "id": "web",
+    "prompt": "Use web search to find the current weather in Tampa, Florida. Return temperature and conditions concisely.",
+    "expected_toolsets": ["web"],
+    "expected_tools": ["web_search"],
+    "must_contain": []
+  },
+  {
+    "id": "skills",
+    "prompt": "Load the hermes-agent skill before answering, then return the exact Hermes CLI command for listing installed plugins.",
+    "expected_toolsets": ["skills"],
+    "expected_tools": ["skill_view"],
+    "must_contain": ["hermes plugins list"]
+  },
+  {
+    "id": "cronjob",
+    "prompt": "Use the cronjob tool to list scheduled jobs. Do not create, change, or remove anything.",
+    "expected_toolsets": ["cronjob"],
+    "expected_tools": ["cronjob"],
+    "must_contain": []
+  },
+  {
+    "id": "session_search",
+    "prompt": "Use session search to find the previous Edith session where Tampa weather was tested. Return its session ID only.",
+    "expected_toolsets": ["session_search"],
+    "expected_tools": ["session_search"],
+    "must_contain": []
+  },
+  {
+    "id": "computer_use",
+    "prompt": "Use computer_use with action list_apps and report whether Safari is listed. Do not focus or raise any window.",
+    "expected_toolsets": ["computer_use"],
+    "expected_tools": ["computer_use"],
+    "must_contain": ["Safari"]
+  },
+  {
+    "id": "code_execution",
+    "prompt": "Use the sandboxed code_execution tool, not terminal, to calculate 7 multiplied by 9. Return only the number.",
+    "expected_toolsets": ["code_execution"],
+    "expected_tools": ["execute_code"],
+    "must_contain": ["63"]
+  },
+  {
+    "id": "todo",
+    "prompt": "Use the todo tool to create a two-item test task list, then report that it was created.",
+    "expected_toolsets": ["todo"],
+    "expected_tools": ["todo"],
+    "must_contain": []
+  }
+]

--- a/benchmarks/prompts.jsonl
+++ b/benchmarks/prompts.jsonl
@@ -1,0 +1,500 @@
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-000", "prompt": "What is photosynthesis? Example 0", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-001", "prompt": "What is photosynthesis? Example 1", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-002", "prompt": "What is photosynthesis? Example 2", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-003", "prompt": "What is photosynthesis? Example 3", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-004", "prompt": "What is photosynthesis? Example 4", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-005", "prompt": "What is photosynthesis? Example 5", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-006", "prompt": "What is photosynthesis? Example 6", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-007", "prompt": "What is photosynthesis? Example 7", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-008", "prompt": "What is photosynthesis? Example 8", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-009", "prompt": "What is photosynthesis? Example 9", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-010", "prompt": "What is photosynthesis? Example 10", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-011", "prompt": "What is photosynthesis? Example 11", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-012", "prompt": "What is photosynthesis? Example 12", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-013", "prompt": "What is photosynthesis? Example 13", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-014", "prompt": "What is photosynthesis? Example 14", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-015", "prompt": "What is photosynthesis? Example 15", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-016", "prompt": "What is photosynthesis? Example 16", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-017", "prompt": "What is photosynthesis? Example 17", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-018", "prompt": "What is photosynthesis? Example 18", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-019", "prompt": "What is photosynthesis? Example 19", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-020", "prompt": "What is photosynthesis? Example 20", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-021", "prompt": "What is photosynthesis? Example 21", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-022", "prompt": "What is photosynthesis? Example 22", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-023", "prompt": "What is photosynthesis? Example 23", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-024", "prompt": "What is photosynthesis? Example 24", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-025", "prompt": "What is photosynthesis? Example 25", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-026", "prompt": "What is photosynthesis? Example 26", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-027", "prompt": "What is photosynthesis? Example 27", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-028", "prompt": "What is photosynthesis? Example 28", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-029", "prompt": "What is photosynthesis? Example 29", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-030", "prompt": "What is photosynthesis? Example 30", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-031", "prompt": "What is photosynthesis? Example 31", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-032", "prompt": "What is photosynthesis? Example 32", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-033", "prompt": "What is photosynthesis? Example 33", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-034", "prompt": "What is photosynthesis? Example 34", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-035", "prompt": "What is photosynthesis? Example 35", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-036", "prompt": "What is photosynthesis? Example 36", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-037", "prompt": "What is photosynthesis? Example 37", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-038", "prompt": "What is photosynthesis? Example 38", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-039", "prompt": "What is photosynthesis? Example 39", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-040", "prompt": "What is photosynthesis? Example 40", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-041", "prompt": "What is photosynthesis? Example 41", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-042", "prompt": "What is photosynthesis? Example 42", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-043", "prompt": "What is photosynthesis? Example 43", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-044", "prompt": "What is photosynthesis? Example 44", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-045", "prompt": "What is photosynthesis? Example 45", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-046", "prompt": "What is photosynthesis? Example 46", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-047", "prompt": "What is photosynthesis? Example 47", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-048", "prompt": "What is photosynthesis? Example 48", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "answer-049", "prompt": "What is photosynthesis? Example 49", "required_toolsets": []}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-000", "prompt": "Find the latest weather in Tampa case 0", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-001", "prompt": "Find the latest weather in Tampa case 1", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-002", "prompt": "Find the latest weather in Tampa case 2", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-003", "prompt": "Find the latest weather in Tampa case 3", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-004", "prompt": "Find the latest weather in Tampa case 4", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-005", "prompt": "Find the latest weather in Tampa case 5", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-006", "prompt": "Find the latest weather in Tampa case 6", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-007", "prompt": "Find the latest weather in Tampa case 7", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-008", "prompt": "Find the latest weather in Tampa case 8", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-009", "prompt": "Find the latest weather in Tampa case 9", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-010", "prompt": "Find the latest weather in Tampa case 10", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-011", "prompt": "Find the latest weather in Tampa case 11", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-012", "prompt": "Find the latest weather in Tampa case 12", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-013", "prompt": "Find the latest weather in Tampa case 13", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-014", "prompt": "Find the latest weather in Tampa case 14", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-015", "prompt": "Find the latest weather in Tampa case 15", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-016", "prompt": "Find the latest weather in Tampa case 16", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-017", "prompt": "Find the latest weather in Tampa case 17", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-018", "prompt": "Find the latest weather in Tampa case 18", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-019", "prompt": "Find the latest weather in Tampa case 19", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-020", "prompt": "Find the latest weather in Tampa case 20", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-021", "prompt": "Find the latest weather in Tampa case 21", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-022", "prompt": "Find the latest weather in Tampa case 22", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-023", "prompt": "Find the latest weather in Tampa case 23", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-024", "prompt": "Find the latest weather in Tampa case 24", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-025", "prompt": "Find the latest weather in Tampa case 25", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-026", "prompt": "Find the latest weather in Tampa case 26", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-027", "prompt": "Find the latest weather in Tampa case 27", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-028", "prompt": "Find the latest weather in Tampa case 28", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-029", "prompt": "Find the latest weather in Tampa case 29", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-030", "prompt": "Find the latest weather in Tampa case 30", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-031", "prompt": "Find the latest weather in Tampa case 31", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-032", "prompt": "Find the latest weather in Tampa case 32", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-033", "prompt": "Find the latest weather in Tampa case 33", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-034", "prompt": "Find the latest weather in Tampa case 34", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-035", "prompt": "Find the latest weather in Tampa case 35", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-036", "prompt": "Find the latest weather in Tampa case 36", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-037", "prompt": "Find the latest weather in Tampa case 37", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-038", "prompt": "Find the latest weather in Tampa case 38", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-039", "prompt": "Find the latest weather in Tampa case 39", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-040", "prompt": "Find the latest weather in Tampa case 40", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-041", "prompt": "Find the latest weather in Tampa case 41", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-042", "prompt": "Find the latest weather in Tampa case 42", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-043", "prompt": "Find the latest weather in Tampa case 43", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-044", "prompt": "Find the latest weather in Tampa case 44", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-045", "prompt": "Find the latest weather in Tampa case 45", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-046", "prompt": "Find the latest weather in Tampa case 46", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-047", "prompt": "Find the latest weather in Tampa case 47", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-048", "prompt": "Find the latest weather in Tampa case 48", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "web-049", "prompt": "Find the latest weather in Tampa case 49", "required_toolsets": ["web"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-000", "prompt": "Log into https://example.com/case/0 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-001", "prompt": "Log into https://example.com/case/1 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-002", "prompt": "Log into https://example.com/case/2 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-003", "prompt": "Log into https://example.com/case/3 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-004", "prompt": "Log into https://example.com/case/4 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-005", "prompt": "Log into https://example.com/case/5 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-006", "prompt": "Log into https://example.com/case/6 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-007", "prompt": "Log into https://example.com/case/7 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-008", "prompt": "Log into https://example.com/case/8 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-009", "prompt": "Log into https://example.com/case/9 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-010", "prompt": "Log into https://example.com/case/10 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-011", "prompt": "Log into https://example.com/case/11 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-012", "prompt": "Log into https://example.com/case/12 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-013", "prompt": "Log into https://example.com/case/13 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-014", "prompt": "Log into https://example.com/case/14 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-015", "prompt": "Log into https://example.com/case/15 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-016", "prompt": "Log into https://example.com/case/16 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-017", "prompt": "Log into https://example.com/case/17 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-018", "prompt": "Log into https://example.com/case/18 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-019", "prompt": "Log into https://example.com/case/19 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-020", "prompt": "Log into https://example.com/case/20 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-021", "prompt": "Log into https://example.com/case/21 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-022", "prompt": "Log into https://example.com/case/22 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-023", "prompt": "Log into https://example.com/case/23 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-024", "prompt": "Log into https://example.com/case/24 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-025", "prompt": "Log into https://example.com/case/25 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-026", "prompt": "Log into https://example.com/case/26 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-027", "prompt": "Log into https://example.com/case/27 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-028", "prompt": "Log into https://example.com/case/28 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-029", "prompt": "Log into https://example.com/case/29 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-030", "prompt": "Log into https://example.com/case/30 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-031", "prompt": "Log into https://example.com/case/31 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-032", "prompt": "Log into https://example.com/case/32 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-033", "prompt": "Log into https://example.com/case/33 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-034", "prompt": "Log into https://example.com/case/34 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-035", "prompt": "Log into https://example.com/case/35 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-036", "prompt": "Log into https://example.com/case/36 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-037", "prompt": "Log into https://example.com/case/37 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-038", "prompt": "Log into https://example.com/case/38 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-039", "prompt": "Log into https://example.com/case/39 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-040", "prompt": "Log into https://example.com/case/40 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-041", "prompt": "Log into https://example.com/case/41 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-042", "prompt": "Log into https://example.com/case/42 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-043", "prompt": "Log into https://example.com/case/43 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-044", "prompt": "Log into https://example.com/case/44 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-045", "prompt": "Log into https://example.com/case/45 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-046", "prompt": "Log into https://example.com/case/46 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-047", "prompt": "Log into https://example.com/case/47 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-048", "prompt": "Log into https://example.com/case/48 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "browser-049", "prompt": "Log into https://example.com/case/49 and submit the form", "required_toolsets": ["browser"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-000", "prompt": "Read this file and inspect its contents case 0", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-001", "prompt": "Read this file and inspect its contents case 1", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-002", "prompt": "Read this file and inspect its contents case 2", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-003", "prompt": "Read this file and inspect its contents case 3", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-004", "prompt": "Read this file and inspect its contents case 4", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-005", "prompt": "Read this file and inspect its contents case 5", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-006", "prompt": "Read this file and inspect its contents case 6", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-007", "prompt": "Read this file and inspect its contents case 7", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-008", "prompt": "Read this file and inspect its contents case 8", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-009", "prompt": "Read this file and inspect its contents case 9", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-010", "prompt": "Read this file and inspect its contents case 10", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-011", "prompt": "Read this file and inspect its contents case 11", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-012", "prompt": "Read this file and inspect its contents case 12", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-013", "prompt": "Read this file and inspect its contents case 13", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-014", "prompt": "Read this file and inspect its contents case 14", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-015", "prompt": "Read this file and inspect its contents case 15", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-016", "prompt": "Read this file and inspect its contents case 16", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-017", "prompt": "Read this file and inspect its contents case 17", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-018", "prompt": "Read this file and inspect its contents case 18", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-019", "prompt": "Read this file and inspect its contents case 19", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-020", "prompt": "Read this file and inspect its contents case 20", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-021", "prompt": "Read this file and inspect its contents case 21", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-022", "prompt": "Read this file and inspect its contents case 22", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-023", "prompt": "Read this file and inspect its contents case 23", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-024", "prompt": "Read this file and inspect its contents case 24", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-025", "prompt": "Read this file and inspect its contents case 25", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-026", "prompt": "Read this file and inspect its contents case 26", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-027", "prompt": "Read this file and inspect its contents case 27", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-028", "prompt": "Read this file and inspect its contents case 28", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-029", "prompt": "Read this file and inspect its contents case 29", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-030", "prompt": "Read this file and inspect its contents case 30", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-031", "prompt": "Read this file and inspect its contents case 31", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-032", "prompt": "Read this file and inspect its contents case 32", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-033", "prompt": "Read this file and inspect its contents case 33", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-034", "prompt": "Read this file and inspect its contents case 34", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-035", "prompt": "Read this file and inspect its contents case 35", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-036", "prompt": "Read this file and inspect its contents case 36", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-037", "prompt": "Read this file and inspect its contents case 37", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-038", "prompt": "Read this file and inspect its contents case 38", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-039", "prompt": "Read this file and inspect its contents case 39", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-040", "prompt": "Read this file and inspect its contents case 40", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-041", "prompt": "Read this file and inspect its contents case 41", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-042", "prompt": "Read this file and inspect its contents case 42", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-043", "prompt": "Read this file and inspect its contents case 43", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-044", "prompt": "Read this file and inspect its contents case 44", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-045", "prompt": "Read this file and inspect its contents case 45", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-046", "prompt": "Read this file and inspect its contents case 46", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-047", "prompt": "Read this file and inspect its contents case 47", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-048", "prompt": "Read this file and inspect its contents case 48", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "file-049", "prompt": "Read this file and inspect its contents case 49", "required_toolsets": ["file"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-000", "prompt": "Run the pytest command for case 0", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-001", "prompt": "Run the pytest command for case 1", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-002", "prompt": "Run the pytest command for case 2", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-003", "prompt": "Run the pytest command for case 3", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-004", "prompt": "Run the pytest command for case 4", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-005", "prompt": "Run the pytest command for case 5", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-006", "prompt": "Run the pytest command for case 6", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-007", "prompt": "Run the pytest command for case 7", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-008", "prompt": "Run the pytest command for case 8", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-009", "prompt": "Run the pytest command for case 9", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-010", "prompt": "Run the pytest command for case 10", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-011", "prompt": "Run the pytest command for case 11", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-012", "prompt": "Run the pytest command for case 12", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-013", "prompt": "Run the pytest command for case 13", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-014", "prompt": "Run the pytest command for case 14", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-015", "prompt": "Run the pytest command for case 15", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-016", "prompt": "Run the pytest command for case 16", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-017", "prompt": "Run the pytest command for case 17", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-018", "prompt": "Run the pytest command for case 18", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-019", "prompt": "Run the pytest command for case 19", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-020", "prompt": "Run the pytest command for case 20", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-021", "prompt": "Run the pytest command for case 21", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-022", "prompt": "Run the pytest command for case 22", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-023", "prompt": "Run the pytest command for case 23", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-024", "prompt": "Run the pytest command for case 24", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-025", "prompt": "Run the pytest command for case 25", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-026", "prompt": "Run the pytest command for case 26", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-027", "prompt": "Run the pytest command for case 27", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-028", "prompt": "Run the pytest command for case 28", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-029", "prompt": "Run the pytest command for case 29", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-030", "prompt": "Run the pytest command for case 30", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-031", "prompt": "Run the pytest command for case 31", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-032", "prompt": "Run the pytest command for case 32", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-033", "prompt": "Run the pytest command for case 33", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-034", "prompt": "Run the pytest command for case 34", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-035", "prompt": "Run the pytest command for case 35", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-036", "prompt": "Run the pytest command for case 36", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-037", "prompt": "Run the pytest command for case 37", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-038", "prompt": "Run the pytest command for case 38", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-039", "prompt": "Run the pytest command for case 39", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-040", "prompt": "Run the pytest command for case 40", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-041", "prompt": "Run the pytest command for case 41", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-042", "prompt": "Run the pytest command for case 42", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-043", "prompt": "Run the pytest command for case 43", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-044", "prompt": "Run the pytest command for case 44", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-045", "prompt": "Run the pytest command for case 45", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-046", "prompt": "Run the pytest command for case 46", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-047", "prompt": "Run the pytest command for case 47", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-048", "prompt": "Run the pytest command for case 48", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "terminal-049", "prompt": "Run the pytest command for case 49", "required_toolsets": ["terminal"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-000", "prompt": "Analyze this screenshot case 0", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-001", "prompt": "Analyze this screenshot case 1", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-002", "prompt": "Analyze this screenshot case 2", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-003", "prompt": "Analyze this screenshot case 3", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-004", "prompt": "Analyze this screenshot case 4", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-005", "prompt": "Analyze this screenshot case 5", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-006", "prompt": "Analyze this screenshot case 6", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-007", "prompt": "Analyze this screenshot case 7", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-008", "prompt": "Analyze this screenshot case 8", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-009", "prompt": "Analyze this screenshot case 9", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-010", "prompt": "Analyze this screenshot case 10", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-011", "prompt": "Analyze this screenshot case 11", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-012", "prompt": "Analyze this screenshot case 12", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-013", "prompt": "Analyze this screenshot case 13", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-014", "prompt": "Analyze this screenshot case 14", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-015", "prompt": "Analyze this screenshot case 15", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-016", "prompt": "Analyze this screenshot case 16", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-017", "prompt": "Analyze this screenshot case 17", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-018", "prompt": "Analyze this screenshot case 18", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-019", "prompt": "Analyze this screenshot case 19", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-020", "prompt": "Analyze this screenshot case 20", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-021", "prompt": "Analyze this screenshot case 21", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-022", "prompt": "Analyze this screenshot case 22", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-023", "prompt": "Analyze this screenshot case 23", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-024", "prompt": "Analyze this screenshot case 24", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-025", "prompt": "Analyze this screenshot case 25", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-026", "prompt": "Analyze this screenshot case 26", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-027", "prompt": "Analyze this screenshot case 27", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-028", "prompt": "Analyze this screenshot case 28", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-029", "prompt": "Analyze this screenshot case 29", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-030", "prompt": "Analyze this screenshot case 30", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-031", "prompt": "Analyze this screenshot case 31", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-032", "prompt": "Analyze this screenshot case 32", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-033", "prompt": "Analyze this screenshot case 33", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-034", "prompt": "Analyze this screenshot case 34", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-035", "prompt": "Analyze this screenshot case 35", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-036", "prompt": "Analyze this screenshot case 36", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-037", "prompt": "Analyze this screenshot case 37", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-038", "prompt": "Analyze this screenshot case 38", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-039", "prompt": "Analyze this screenshot case 39", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-040", "prompt": "Analyze this screenshot case 40", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-041", "prompt": "Analyze this screenshot case 41", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-042", "prompt": "Analyze this screenshot case 42", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-043", "prompt": "Analyze this screenshot case 43", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-044", "prompt": "Analyze this screenshot case 44", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-045", "prompt": "Analyze this screenshot case 45", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-046", "prompt": "Analyze this screenshot case 46", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-047", "prompt": "Analyze this screenshot case 47", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-048", "prompt": "Analyze this screenshot case 48", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "image-049", "prompt": "Analyze this screenshot case 49", "required_toolsets": ["vision"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-000", "prompt": "Generate a logo image variation 0", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-001", "prompt": "Generate a logo image variation 1", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-002", "prompt": "Generate a logo image variation 2", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-003", "prompt": "Generate a logo image variation 3", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-004", "prompt": "Generate a logo image variation 4", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-005", "prompt": "Generate a logo image variation 5", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-006", "prompt": "Generate a logo image variation 6", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-007", "prompt": "Generate a logo image variation 7", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-008", "prompt": "Generate a logo image variation 8", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-009", "prompt": "Generate a logo image variation 9", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-010", "prompt": "Generate a logo image variation 10", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-011", "prompt": "Generate a logo image variation 11", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-012", "prompt": "Generate a logo image variation 12", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-013", "prompt": "Generate a logo image variation 13", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-014", "prompt": "Generate a logo image variation 14", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-015", "prompt": "Generate a logo image variation 15", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-016", "prompt": "Generate a logo image variation 16", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-017", "prompt": "Generate a logo image variation 17", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-018", "prompt": "Generate a logo image variation 18", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-019", "prompt": "Generate a logo image variation 19", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-020", "prompt": "Generate a logo image variation 20", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-021", "prompt": "Generate a logo image variation 21", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-022", "prompt": "Generate a logo image variation 22", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-023", "prompt": "Generate a logo image variation 23", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-024", "prompt": "Generate a logo image variation 24", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-025", "prompt": "Generate a logo image variation 25", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-026", "prompt": "Generate a logo image variation 26", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-027", "prompt": "Generate a logo image variation 27", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-028", "prompt": "Generate a logo image variation 28", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-029", "prompt": "Generate a logo image variation 29", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-030", "prompt": "Generate a logo image variation 30", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-031", "prompt": "Generate a logo image variation 31", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-032", "prompt": "Generate a logo image variation 32", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-033", "prompt": "Generate a logo image variation 33", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-034", "prompt": "Generate a logo image variation 34", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-035", "prompt": "Generate a logo image variation 35", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-036", "prompt": "Generate a logo image variation 36", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-037", "prompt": "Generate a logo image variation 37", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-038", "prompt": "Generate a logo image variation 38", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-039", "prompt": "Generate a logo image variation 39", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-040", "prompt": "Generate a logo image variation 40", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-041", "prompt": "Generate a logo image variation 41", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-042", "prompt": "Generate a logo image variation 42", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-043", "prompt": "Generate a logo image variation 43", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-044", "prompt": "Generate a logo image variation 44", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-045", "prompt": "Generate a logo image variation 45", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-046", "prompt": "Generate a logo image variation 46", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-047", "prompt": "Generate a logo image variation 47", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-048", "prompt": "Generate a logo image variation 48", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "imagegen-049", "prompt": "Generate a logo image variation 49", "required_toolsets": ["image_gen"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-000", "prompt": "Remember this fact number 0", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-001", "prompt": "Remember this fact number 1", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-002", "prompt": "Remember this fact number 2", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-003", "prompt": "Remember this fact number 3", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-004", "prompt": "Remember this fact number 4", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-005", "prompt": "Remember this fact number 5", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-006", "prompt": "Remember this fact number 6", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-007", "prompt": "Remember this fact number 7", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-008", "prompt": "Remember this fact number 8", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-009", "prompt": "Remember this fact number 9", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-010", "prompt": "Remember this fact number 10", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-011", "prompt": "Remember this fact number 11", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-012", "prompt": "Remember this fact number 12", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-013", "prompt": "Remember this fact number 13", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-014", "prompt": "Remember this fact number 14", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-015", "prompt": "Remember this fact number 15", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-016", "prompt": "Remember this fact number 16", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-017", "prompt": "Remember this fact number 17", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-018", "prompt": "Remember this fact number 18", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-019", "prompt": "Remember this fact number 19", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-020", "prompt": "Remember this fact number 20", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-021", "prompt": "Remember this fact number 21", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-022", "prompt": "Remember this fact number 22", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-023", "prompt": "Remember this fact number 23", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-024", "prompt": "Remember this fact number 24", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-025", "prompt": "Remember this fact number 25", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-026", "prompt": "Remember this fact number 26", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-027", "prompt": "Remember this fact number 27", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-028", "prompt": "Remember this fact number 28", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-029", "prompt": "Remember this fact number 29", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-030", "prompt": "Remember this fact number 30", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-031", "prompt": "Remember this fact number 31", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-032", "prompt": "Remember this fact number 32", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-033", "prompt": "Remember this fact number 33", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-034", "prompt": "Remember this fact number 34", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-035", "prompt": "Remember this fact number 35", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-036", "prompt": "Remember this fact number 36", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-037", "prompt": "Remember this fact number 37", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-038", "prompt": "Remember this fact number 38", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-039", "prompt": "Remember this fact number 39", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-040", "prompt": "Remember this fact number 40", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-041", "prompt": "Remember this fact number 41", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-042", "prompt": "Remember this fact number 42", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-043", "prompt": "Remember this fact number 43", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-044", "prompt": "Remember this fact number 44", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-045", "prompt": "Remember this fact number 45", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-046", "prompt": "Remember this fact number 46", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-047", "prompt": "Remember this fact number 47", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-048", "prompt": "Remember this fact number 48", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "memory-049", "prompt": "Remember this fact number 49", "required_toolsets": ["memory"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-000", "prompt": "Schedule a cron reminder every day case 0", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-001", "prompt": "Schedule a cron reminder every day case 1", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-002", "prompt": "Schedule a cron reminder every day case 2", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-003", "prompt": "Schedule a cron reminder every day case 3", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-004", "prompt": "Schedule a cron reminder every day case 4", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-005", "prompt": "Schedule a cron reminder every day case 5", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-006", "prompt": "Schedule a cron reminder every day case 6", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-007", "prompt": "Schedule a cron reminder every day case 7", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-008", "prompt": "Schedule a cron reminder every day case 8", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-009", "prompt": "Schedule a cron reminder every day case 9", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-010", "prompt": "Schedule a cron reminder every day case 10", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-011", "prompt": "Schedule a cron reminder every day case 11", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-012", "prompt": "Schedule a cron reminder every day case 12", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-013", "prompt": "Schedule a cron reminder every day case 13", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-014", "prompt": "Schedule a cron reminder every day case 14", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-015", "prompt": "Schedule a cron reminder every day case 15", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-016", "prompt": "Schedule a cron reminder every day case 16", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-017", "prompt": "Schedule a cron reminder every day case 17", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-018", "prompt": "Schedule a cron reminder every day case 18", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-019", "prompt": "Schedule a cron reminder every day case 19", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-020", "prompt": "Schedule a cron reminder every day case 20", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-021", "prompt": "Schedule a cron reminder every day case 21", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-022", "prompt": "Schedule a cron reminder every day case 22", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-023", "prompt": "Schedule a cron reminder every day case 23", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-024", "prompt": "Schedule a cron reminder every day case 24", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-025", "prompt": "Schedule a cron reminder every day case 25", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-026", "prompt": "Schedule a cron reminder every day case 26", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-027", "prompt": "Schedule a cron reminder every day case 27", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-028", "prompt": "Schedule a cron reminder every day case 28", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-029", "prompt": "Schedule a cron reminder every day case 29", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-030", "prompt": "Schedule a cron reminder every day case 30", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-031", "prompt": "Schedule a cron reminder every day case 31", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-032", "prompt": "Schedule a cron reminder every day case 32", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-033", "prompt": "Schedule a cron reminder every day case 33", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-034", "prompt": "Schedule a cron reminder every day case 34", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-035", "prompt": "Schedule a cron reminder every day case 35", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-036", "prompt": "Schedule a cron reminder every day case 36", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-037", "prompt": "Schedule a cron reminder every day case 37", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-038", "prompt": "Schedule a cron reminder every day case 38", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-039", "prompt": "Schedule a cron reminder every day case 39", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-040", "prompt": "Schedule a cron reminder every day case 40", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-041", "prompt": "Schedule a cron reminder every day case 41", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-042", "prompt": "Schedule a cron reminder every day case 42", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-043", "prompt": "Schedule a cron reminder every day case 43", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-044", "prompt": "Schedule a cron reminder every day case 44", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-045", "prompt": "Schedule a cron reminder every day case 45", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-046", "prompt": "Schedule a cron reminder every day case 46", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-047", "prompt": "Schedule a cron reminder every day case 47", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-048", "prompt": "Schedule a cron reminder every day case 48", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": true, "id": "cron-049", "prompt": "Schedule a cron reminder every day case 49", "required_toolsets": ["cronjob"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-000", "prompt": "Delegate this to a subagent case 0", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-001", "prompt": "Delegate this to a subagent case 1", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-002", "prompt": "Delegate this to a subagent case 2", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-003", "prompt": "Delegate this to a subagent case 3", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-004", "prompt": "Delegate this to a subagent case 4", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-005", "prompt": "Delegate this to a subagent case 5", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-006", "prompt": "Delegate this to a subagent case 6", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-007", "prompt": "Delegate this to a subagent case 7", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-008", "prompt": "Delegate this to a subagent case 8", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-009", "prompt": "Delegate this to a subagent case 9", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-010", "prompt": "Delegate this to a subagent case 10", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-011", "prompt": "Delegate this to a subagent case 11", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-012", "prompt": "Delegate this to a subagent case 12", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-013", "prompt": "Delegate this to a subagent case 13", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-014", "prompt": "Delegate this to a subagent case 14", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-015", "prompt": "Delegate this to a subagent case 15", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-016", "prompt": "Delegate this to a subagent case 16", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-017", "prompt": "Delegate this to a subagent case 17", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-018", "prompt": "Delegate this to a subagent case 18", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-019", "prompt": "Delegate this to a subagent case 19", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-020", "prompt": "Delegate this to a subagent case 20", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-021", "prompt": "Delegate this to a subagent case 21", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-022", "prompt": "Delegate this to a subagent case 22", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-023", "prompt": "Delegate this to a subagent case 23", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-024", "prompt": "Delegate this to a subagent case 24", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-025", "prompt": "Delegate this to a subagent case 25", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-026", "prompt": "Delegate this to a subagent case 26", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-027", "prompt": "Delegate this to a subagent case 27", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-028", "prompt": "Delegate this to a subagent case 28", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-029", "prompt": "Delegate this to a subagent case 29", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-030", "prompt": "Delegate this to a subagent case 30", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-031", "prompt": "Delegate this to a subagent case 31", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-032", "prompt": "Delegate this to a subagent case 32", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-033", "prompt": "Delegate this to a subagent case 33", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-034", "prompt": "Delegate this to a subagent case 34", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-035", "prompt": "Delegate this to a subagent case 35", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-036", "prompt": "Delegate this to a subagent case 36", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-037", "prompt": "Delegate this to a subagent case 37", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-038", "prompt": "Delegate this to a subagent case 38", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-039", "prompt": "Delegate this to a subagent case 39", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-040", "prompt": "Delegate this to a subagent case 40", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-041", "prompt": "Delegate this to a subagent case 41", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-042", "prompt": "Delegate this to a subagent case 42", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-043", "prompt": "Delegate this to a subagent case 43", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-044", "prompt": "Delegate this to a subagent case 44", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-045", "prompt": "Delegate this to a subagent case 45", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-046", "prompt": "Delegate this to a subagent case 46", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-047", "prompt": "Delegate this to a subagent case 47", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-048", "prompt": "Delegate this to a subagent case 48", "required_toolsets": ["delegation"]}
+{"acceptable_extra_toolsets": [], "critical": false, "id": "delegate-049", "prompt": "Delegate this to a subagent case 49", "required_toolsets": ["delegation"]}

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Evaluate deterministic routing against the versioned prompt corpus."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_benchmark"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+plugin = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = plugin
+spec.loader.exec_module(plugin)
+
+from hermes_tool_router_benchmark.policy import _predict_toolsets_by_rules
+from scoring import score_routes
+
+AVAILABLE = {
+    "web", "browser", "file", "terminal", "git", "vision", "image_gen",
+    "video", "video_gen", "memory", "session_search", "cronjob", "delegation",
+    "clarify", "skills",
+}
+
+
+def main() -> int:
+    corpus = Path(__file__).with_name("prompts.jsonl")
+    pairs: list[tuple[set[str], set[str]]] = []
+    critical_misses: list[str] = []
+    full_fallbacks = 0
+    for line in corpus.read_text().splitlines():
+        row = json.loads(line)
+        required = set(row["required_toolsets"])
+        predicted, _reason = _predict_toolsets_by_rules(row["prompt"], AVAILABLE)
+        if predicted is None:
+            full_fallbacks += 1
+            predicted = set(AVAILABLE)
+        pairs.append((required, set(predicted)))
+        if row.get("critical") and not required <= set(predicted):
+            critical_misses.append(row["id"])
+
+    result = score_routes(pairs)
+    result.update({
+        "records": len(pairs),
+        "full_fallback_rate": full_fallbacks / len(pairs),
+        "critical_misses": critical_misses,
+    })
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 1 if critical_misses else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/scoring.py
+++ b/benchmarks/scoring.py
@@ -1,0 +1,19 @@
+"""Pure benchmark metric calculations."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def score_routes(records: Iterable[tuple[set[str], set[str]]]) -> dict[str, float]:
+    """Score ``(required, predicted)`` toolset pairs."""
+    pairs = list(records)
+    required_total = sum(len(required) for required, _ in pairs)
+    predicted_total = sum(len(predicted) for _, predicted in pairs)
+    true_positive = sum(len(required & predicted) for required, predicted in pairs)
+    exact = sum(required == predicted for required, predicted in pairs)
+    return {
+        "required_recall": true_positive / required_total if required_total else 1.0,
+        "toolset_precision": true_positive / predicted_total if predicted_total else 1.0,
+        "exact_set_accuracy": exact / len(pairs) if pairs else 1.0,
+    }

--- a/classifier.py
+++ b/classifier.py
@@ -1,0 +1,96 @@
+"""Bounded, structured optional classifier support."""
+
+from __future__ import annotations
+
+import json
+import math
+import queue
+import threading
+from typing import Callable, Iterable, TypeVar
+
+try:
+    from .models import RouteAction, RouteDecision
+except ImportError:  # pragma: no cover
+    from models import RouteAction, RouteDecision
+
+
+T = TypeVar("T")
+
+
+def call_with_hard_timeout(call: Callable[[], T], timeout_seconds: float) -> tuple[bool, T | None]:
+    """Run a call on a daemon thread and return at the deadline without joining it."""
+    results: queue.Queue[tuple[bool, object]] = queue.Queue(maxsize=1)
+
+    def worker() -> None:
+        try:
+            results.put((True, call()), block=False)
+        except BaseException as exc:  # propagated on the caller thread
+            results.put((False, exc), block=False)
+
+    threading.Thread(target=worker, name="hermes-tool-router", daemon=True).start()
+    try:
+        succeeded, value = results.get(timeout=max(0.001, timeout_seconds))
+    except queue.Empty:
+        return False, None
+    if not succeeded:
+        raise value  # type: ignore[misc]
+    return True, value  # type: ignore[return-value]
+
+
+def _strip_fence(content: str) -> str:
+    text = (content or "").strip()
+    if text.startswith("```"):
+        first_newline = text.find("\n")
+        text = text[first_newline + 1 :] if first_newline >= 0 else ""
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+    return text.strip()
+
+
+def parse_classifier_output(
+    content: str,
+    available_toolsets: Iterable[str],
+    confidence_threshold: float,
+) -> RouteDecision:
+    """Validate classifier JSON and fail open on every ambiguous condition."""
+
+    try:
+        result = json.loads(_strip_fence(content))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return RouteDecision.full(reason_code="invalid_json", source="classifier")
+    if not isinstance(result, dict):
+        return RouteDecision.full(reason_code="invalid_shape", source="classifier")
+
+    raw_confidence = result.get("confidence")
+    if isinstance(raw_confidence, bool) or not isinstance(raw_confidence, (int, float)):
+        return RouteDecision.full(reason_code="missing_confidence", source="classifier")
+    confidence = float(raw_confidence)
+    if not math.isfinite(confidence) or not 0.0 <= confidence <= 1.0:
+        return RouteDecision.full(reason_code="invalid_confidence", source="classifier")
+    if confidence < confidence_threshold:
+        return RouteDecision.full(
+            reason_code="low_confidence", confidence=confidence, source="classifier"
+        )
+
+    action = str(result.get("action") or "").strip().lower()
+    reason = str(result.get("reason_code") or "classifier").strip()[:80]
+    if action == RouteAction.FULL.value:
+        return RouteDecision.full(reason_code=reason, confidence=confidence, source="classifier")
+    if action == RouteAction.NO_TOOLS.value:
+        return RouteDecision.no_tools(reason_code=reason, confidence=confidence, source="classifier")
+    if action != RouteAction.NARROW.value:
+        return RouteDecision.full(reason_code="unknown_action", confidence=confidence, source="classifier")
+
+    raw_toolsets = result.get("toolsets")
+    if not isinstance(raw_toolsets, list) or not raw_toolsets:
+        return RouteDecision.full(reason_code="invalid_toolsets", confidence=confidence, source="classifier")
+    selected = {str(name).strip() for name in raw_toolsets if str(name).strip()}
+    available = set(available_toolsets)
+    if not selected or not selected <= available:
+        return RouteDecision.full(reason_code="unknown_toolset", confidence=confidence, source="classifier")
+    return RouteDecision.narrow(
+        selected,
+        confidence=confidence,
+        reason_code=reason,
+        source="classifier",
+    )

--- a/compat.py
+++ b/compat.py
@@ -1,0 +1,26 @@
+"""Hermes hook compatibility detection."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Iterable
+
+
+class CompatibilityMode(str, Enum):
+    PRODUCTION = "production"
+    REDUCED_SAFETY = "reduced_safety"
+    LATE_COMPATIBILITY = "late_compatibility"
+    UNSUPPORTED_FOR_TOKEN_SAVINGS = "unsupported_for_token_savings"
+
+
+def detect_compatibility(hooks: Iterable[str]) -> CompatibilityMode:
+    available = set(hooks)
+    early = "pre_tool_surface_build" in available or "pre_turn_context_build" in available
+    recovery = "on_unavailable_tool_call" in available
+    if early and recovery:
+        return CompatibilityMode.PRODUCTION
+    if early:
+        return CompatibilityMode.REDUCED_SAFETY
+    if "pre_llm_call" in available:
+        return CompatibilityMode.LATE_COMPATIBILITY
+    return CompatibilityMode.UNSUPPORTED_FOR_TOKEN_SAVINGS

--- a/config.py
+++ b/config.py
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "hermes-token-router"
 CONFIG_FILE = Path(__file__).resolve().parent / "config.yaml"
-DEFAULT_ROUTER_MODEL = "meta-llama/llama-3.1-8b-instruct"
-DEFAULT_ROUTER_PROVIDER = "openrouter"
+DEFAULT_ROUTER_MODEL = "deepseek-chat"
+DEFAULT_ROUTER_PROVIDER = "deepseek"
 def _load_config() -> dict:
     """Load router config from plugin's config.yaml.
 
@@ -37,27 +37,16 @@ def _get_profile_config(cfg: dict) -> dict:
     if explicit_profile:
         profile_name = explicit_profile
     else:
-        # No explicit profile env; prefer any enabled profile in our config.
-        # This lets the router work even when Hermes doesn't export HERMES_PROFILE.
-        profiles_cfg = cfg.get("profiles", {}) or {}
-        candidate = next(
-            (name for name, v in profiles_cfg.items() if v.get("enabled")),
-            None,
-        )
-
-        # Fallback: infer from HERMES_HOME path.
+        # No explicit profile env: infer only from the canonical Hermes home.
+        # Never activate the first enabled profile by insertion order; applying
+        # another profile's policy is less safe than failing closed here.
         hermes_home = os.environ.get("HERMES_HOME", "")
         inferred = "default"
         if hermes_home:
-            profiles_root = Path(hermes_home).parent / "profiles"
-            if profiles_root.exists():
-                for child in profiles_root.iterdir():
-                    if child.is_dir() and str(child.resolve()) == Path(hermes_home).resolve():
-                        inferred = child.name
-                        break
-
-        # Use enabled config profile if present; else use inferred.
-        profile_name = candidate or inferred
+            home_path = Path(hermes_home).expanduser().resolve()
+            if home_path.parent.name == "profiles":
+                inferred = home_path.name
+        profile_name = inferred
 
     # Look up per-profile config
     profiles_config = cfg.get("profiles", {})
@@ -73,20 +62,48 @@ def _get_profile_config(cfg: dict) -> dict:
 
     # Not enabled for this profile
     return {"enabled": False, "_profile_name": profile_name}
+def _is_classifier_enabled(profile_cfg: dict) -> bool:
+    """The external classifier is opt-in; deterministic routing works without it."""
+    classifier = profile_cfg.get("classifier", {})
+    return bool(isinstance(classifier, dict) and classifier.get("enabled", False))
+
+
+def _get_classifier_connection(profile_cfg: dict) -> tuple[str, str]:
+    """Return custom OpenAI-compatible base URL and API-key env name."""
+    classifier = profile_cfg.get("classifier", {})
+    if not isinstance(classifier, dict):
+        return "", ""
+    base_url = classifier.get("base_url")
+    api_key_env = classifier.get("api_key_env")
+    return (
+        base_url.strip() if isinstance(base_url, str) else "",
+        api_key_env.strip() if isinstance(api_key_env, str) else "",
+    )
+
+
 def _get_router_model(profile_cfg: dict) -> str:
-    """Return the effective router model from config."""
-    router_model = profile_cfg.get("router_model", DEFAULT_ROUTER_MODEL)
+    """Return the effective classifier model (v2 nested config, then legacy)."""
+    classifier = profile_cfg.get("classifier", {})
+    nested = classifier.get("model") if isinstance(classifier, dict) else None
+    router_model = nested or profile_cfg.get("router_model", DEFAULT_ROUTER_MODEL)
     if not isinstance(router_model, str) or not router_model.strip():
         return DEFAULT_ROUTER_MODEL
     return router_model.strip()
 def _get_router_provider(profile_cfg: dict) -> str:
-    """Return the effective router provider from config."""
-    router_provider = profile_cfg.get("router_provider", DEFAULT_ROUTER_PROVIDER)
+    """Return the effective classifier provider (v2 nested config, then legacy)."""
+    classifier = profile_cfg.get("classifier", {})
+    nested = classifier.get("provider") if isinstance(classifier, dict) else None
+    router_provider = nested or profile_cfg.get("router_provider", DEFAULT_ROUTER_PROVIDER)
     if not isinstance(router_provider, str) or not router_provider.strip():
         return DEFAULT_ROUTER_PROVIDER
     return router_provider.strip()
 def _is_router_active(cfg: dict = None) -> bool:
-    """Check if router is enabled for the current profile."""
+    """Check if router is enabled for the current profile or process override."""
+    override = os.environ.get("HERMES_TOKEN_ROUTER_ENABLED", "").strip().lower()
+    if override in {"0", "false", "no", "off"}:
+        return False
+    if override in {"1", "true", "yes", "on"}:
+        return True
     if cfg is None:
         cfg = _load_config()
     profile_cfg = _get_profile_config(cfg)

--- a/config.yaml
+++ b/config.yaml
@@ -1,21 +1,27 @@
-# Hermes Tool Router configuration
-# Copy this file with the plugin and enable either global or selected profiles.
-# Safe default: disabled until you opt in.
-
+# Hermes Tool Router v2 configuration — disabled until explicitly enabled.
 global:
   enabled: false
-  # floor_toolsets are always kept when routing narrows the tool surface.
-  # Set [] for maximum token savings and rely on request_toolset recovery.
-  floor_toolsets: [terminal, file, web]
+  routing_scope: first_turn
+  expansion_mode: monotonic
+  shrink_mid_session: false
+  floor_toolsets: []
   deterministic_rules_enabled: true
-  confidence_threshold: 0.0
-  long_message_decline_chars: 12000
-  short_message_bypass_chars: 0
-  router_provider: deepseek
-  router_model: deepseek-chat
+  confidence_threshold: 0.90
+  router_timeout_ms: 750
+  router_hard_timeout_ms: 1200
+  fail_open: true
+  auto_recover_registered_tools: true
+  classifier:
+    enabled: false
+    provider: null  # defaults to direct deepseek when enabled
+    model: null     # defaults to deepseek-chat
+    base_url: null
+    api_key_env: null
+  metrics:
+    enabled: true
+    local_only: true
+    retain_days: 30
 
 profiles:
-  # Example profile-specific override. Rename "router-test" to your test profile name.
   router-test:
     enabled: false
-    floor_toolsets: [terminal, file, web]

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -1,0 +1,73 @@
+"""Local-only compatibility and readiness diagnostics."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+try:
+    from .compat import CompatibilityMode, detect_compatibility
+except ImportError:  # pragma: no cover
+    from compat import CompatibilityMode, detect_compatibility
+
+
+def build_report(
+    *,
+    hooks: Iterable[str],
+    middleware: Iterable[str] = (),
+    toolsets: Iterable[str],
+    profile_name: str,
+    enabled: bool,
+) -> dict:
+    hook_set = set(hooks)
+    middleware_set = set(middleware)
+    mode = detect_compatibility(hook_set)
+    early = mode in {CompatibilityMode.PRODUCTION, CompatibilityMode.REDUCED_SAFETY}
+    routes_before_request = early or mode is CompatibilityMode.LATE_COMPATIBILITY
+    return {
+        "profile": profile_name,
+        "enabled": bool(enabled),
+        "compatibility_mode": mode.value,
+        "first_turn_savings_available": bool(enabled and routes_before_request),
+        "preflight_routing_available": bool(enabled and early),
+        "automatic_recovery_available": (
+            "on_unavailable_tool_call" in hook_set or "tool_request" in middleware_set
+        ),
+        "registered_toolset_count": len(set(toolsets)),
+        "hooks": sorted(hook_set),
+        "middleware": sorted(middleware_set),
+    }
+
+
+def inspect_live_runtime(profile_name: str = "default", enabled: bool = True) -> dict:
+    try:
+        from hermes_cli.plugins import VALID_HOOKS
+    except Exception:
+        VALID_HOOKS = set()
+    try:
+        from hermes_cli.middleware import VALID_MIDDLEWARE
+    except Exception:
+        VALID_MIDDLEWARE = set()
+    try:
+        import model_tools  # noqa: F401 - triggers built-in tool registration
+        from tools.registry import registry
+        toolsets = set(registry.get_registered_toolset_names())
+    except Exception:
+        toolsets = set()
+    return build_report(
+        hooks=VALID_HOOKS,
+        middleware=VALID_MIDDLEWARE,
+        toolsets=toolsets,
+        profile_name=profile_name,
+        enabled=enabled,
+    )
+
+
+def main() -> int:
+    report = inspect_live_runtime()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["first_turn_savings_available"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture
+
+The v2 router classifies the initial user turn, applies the smallest confidently sufficient toolset, and keeps that serialized schema surface stable. State is stored on the live agent. Recovery only adds capabilities; it never removes them.
+
+## Invariants
+
+1. Route before schema assembly or do not claim savings.
+2. Classify once per session.
+3. `active_toolsets` is monotonic.
+4. Missing/invalid confidence fails open.
+5. Dynamic registry names drive recovery schemas.
+6. Unknown profiles never inherit the first enabled profile by insertion order.
+7. External classification is opt-in.
+
+## Required upstream seams
+
+- Early surface hook: `pre_tool_surface_build` or `pre_turn_context_build`, with the live agent passed explicitly.
+- Tool-request middleware: Hermes's existing `tool_request` middleware runs before validation/dispatch. The plugin uses it to expand a registered pruned tool's owner toolset; normal check functions, approvals, and execution remain authoritative.

--- a/docs/baselines/v0.2-rc1.md
+++ b/docs/baselines/v0.2-rc1.md
@@ -1,0 +1,27 @@
+# v0.2 RC live schema-token baseline
+
+Measured against the local Hermes Agent checkout on 2026-07-10 using `agent.model_metadata.estimate_request_tokens_rough` and the live requirement-gated registry.
+
+- Hermes source commit previously inspected: `88a58ff13`
+- Available live tool definitions: 39
+- Full request estimate: 18,627 tokens
+
+| Routed toolsets | Tools | Request estimate | Reduction |
+|---|---:|---:|---:|
+| `web` | 2 | 490 | 97.37% |
+| `file,terminal` | 6 | 3,207 | 82.78% |
+| `browser,web` | 14 | 3,364 | 81.94% |
+
+Commands:
+
+```bash
+~/.hermes/hermes-agent/.venv/bin/python scripts/measure_schema_tokens.py \
+  --hermes-source ~/.hermes/hermes-agent --toolsets web
+```
+
+Caveats:
+
+- These are Hermes's rough request estimates, not provider-billed token receipts.
+- Registry `check_fn` gating excluded integrations not configured in the measurement process.
+- The always-visible recovery schema was not registered in this isolated measurement; it is small but nonzero.
+- Real task parity and cache-read behavior still require a live alternate-profile soak.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,15 @@
+# Compatibility
+
+| Runtime hooks | Mode | First-turn savings | Recovery |
+|---|---|---:|---|
+| Early or late routing hook + `tool_request` middleware | production recovery | Yes | Automatic plus `request_toolset` |
+| Routing hook without `tool_request` middleware | reduced safety | Yes | `request_toolset` only |
+| No routing hook | unsupported for token savings | No | None |
+
+The repository originally documented `pre_turn_context_build` as implemented in Hermes on July 1, 2026. Current Hermes source must still be checked because hook availability can change between releases. `diagnostics.py` reads the live hook registry rather than trusting version strings.
+
+The plugin fails open when no routing hook is available. The stock `pre_llm_call` path can reduce the actual provider payload because it runs before request assembly, though it does not affect the earlier preflight estimate and currently relies on compatibility agent lookup.
+
+## Current tested requirement
+
+Current Hermes needs no source modification for the tested late-compatibility mode. The plugin uses stock `pre_llm_call` and `tool_request` middleware. An early `pre_turn_context_build`-style hook remains an optional upstream optimization for reducing preflight work, not an installation requirement.

--- a/docs/live-evaluation-v0.2-rc1.md
+++ b/docs/live-evaluation-v0.2-rc1.md
@@ -1,0 +1,87 @@
+# Live evaluation: v0.2 RC1
+
+Date: 2026-07-11
+
+Profile: `edith` (isolated test profile)
+
+Model: `openai/gpt-5.4-mini` through OpenRouter
+
+Hermes compatibility mode: `pre_llm_call` late compatibility
+
+Router classifier: disabled; deterministic policy only
+
+## Runtime architecture
+
+The tested router requires **no Hermes Agent core modifications**. It uses stock extension points:
+
+- `pre_llm_call` narrows the live tool surface before the provider request.
+- `tool_request` middleware expands a registry-known pruned tool before normal validation and execution.
+- `request_toolset` provides explicit, model-visible recovery and validates names against the live registry at call time.
+
+An optional earlier hook could reduce internal preflight work, but it is not required for provider-request token savings or tool execution. No router patch is present in `apply-patches.sh`.
+
+## Paired methodology
+
+The evaluator launches fresh Edith sessions with the same profile and prompt in two modes:
+
+1. Router enabled.
+2. Router bypassed for that subprocess with `HERMES_TOKEN_ROUTER_ENABLED=false`.
+
+The primary efficiency metric is the actual `in=` token count from Hermes's first provider request log entry. SQLite session `input_tokens` is not used for schema-footprint comparisons because it excludes cache-read tokens and aggregates billing across calls.
+
+The fixed safe-core corpus covers:
+
+- no-tool answer
+- terminal
+- file
+- web
+- skills
+- cronjob
+- session search
+- computer use
+- sandboxed code execution
+- todo
+
+## Results
+
+- Cases passed: **10/10**
+- Required-toolset recall: **100%**
+- Exact route accuracy: **100%**
+- Tool-call success: **100%**
+- Answer accuracy: **100%**
+- Autoresearch score: **94.239983**
+- Evaluator wall time: **118.505 seconds**
+
+### First-provider-request tokens
+
+| Case | Routed | Full tools | Reduction |
+|---|---:|---:|---:|
+| no-tool answer | 7,911 | 22,125 | 64.24% |
+| terminal | 9,305 | 22,154 | 58.00% |
+| web | 8,288 | 22,135 | 62.56% |
+| **Average** | — | — | **61.60%** |
+
+## Reproduction
+
+Direct evaluator:
+
+```bash
+.venv/bin/python scripts/live_router_evaluator.py \
+  --output runs/live_router_eval.json
+```
+
+Through `hermes-autoresearch`:
+
+```bash
+PYTHONPATH=~/Desktop/hermes-autoresearch/src \
+  .venv/bin/python -m hermes_autoresearch.cli \
+  --config autoresearch/router_live_eval.json
+```
+
+The autoresearch run is bounded to one evaluator trial and a 30-minute hard ceiling. The current corpus normally finishes in about two minutes.
+
+## Scope and caveats
+
+This report validates the safe representative core, not every requirement-gated or externally billable integration. Image generation, video generation/analysis, TTS, browser automation, vision, memory writes, delegation, and platform-specific integrations require a separate controlled corpus.
+
+The live average is below the current aspirational 70% stable-release token-reduction gate. RC1 should therefore remain a release candidate even though routing and tool execution passed this corpus without regression.

--- a/docs/pre_turn_context_build_hook.md
+++ b/docs/pre_turn_context_build_hook.md
@@ -1,10 +1,10 @@
 # Proposal: `pre_turn_context_build` Hook for Hermes
 
-## Status: Implemented
+## Status: Version-dependent
 
-Implemented in Hermes core on 2026-07-01. The core hook now fires from `agent/turn_context.py` before system prompt assembly, skill injection/filtering, preflight token estimate/compression, and final provider tool schema assembly. The token-router plugin now registers `pre_turn_context_build` as its primary routing hook and no longer monkey-patches `agent.turn_context.build_turn_context`.
+The hook existed in a July 1, 2026 Hermes build but is not present in every later/current hook registry. The plugin therefore supports stock `pre_llm_call` as a compatibility route and uses live diagnostics rather than version strings. This document remains the proposal for a cleaner explicit-agent, pre-preflight surface.
 
-Minimum Hermes requirement for primary routing: a Hermes build containing the 2026-07-01 `pre_turn_context_build` hook in `agent/turn_context.py` and the matching valid-hook entry in `hermes_cli/plugins.py`. Older Hermes builds continue through the plugin's late `pre_llm_call` fallback, but that fallback cannot reduce prompt/tool schema bloat before turn-context assembly.
+Minimum Hermes requirement for the clean pre-preflight path: a build containing `pre_turn_context_build` (or an equivalent early surface hook) and its valid-hook registry entry. Builds exposing only `pre_llm_call` use the stock late compatibility path, which still narrows the actual provider request but cannot change work already performed by the initial preflight stage.
 
 ## Summary
 

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -1,0 +1,19 @@
+# Safety model
+
+The router is an optimization, never an authorization boundary. It may remove schemas from a model request, but it must not bypass Hermes tool validation, terminal approvals, credential requirements, or platform restrictions.
+
+## Fail-open conditions
+
+- Unknown profile identity
+- Missing early hook
+- Registry lookup or generation mismatch
+- Classifier disabled, unavailable, timed out, malformed, low-confidence, or returns unknown toolsets
+- Partial/failed expansion
+
+## Recovery
+
+`request_toolset` accepts one or more live registry toolset names or a specific registered tool name. Successful expansion is permanent for the session. Automatic recovery uses Hermes's `tool_request` middleware before dispatch and never bypasses normal validation or approvals.
+
+## Privacy
+
+Deterministic routing is local. External classification is opt-in. Local metrics must not store raw prompts by default, and no telemetry is sent externally by this plugin.

--- a/intent.py
+++ b/intent.py
@@ -1,0 +1,164 @@
+"""High-precision intent classification for deterministic tool routing."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import FrozenSet
+
+
+class Intent(str, Enum):
+    ANSWER_ONLY = "answer_only"
+    READ_LOCAL = "read_local"
+    WRITE_LOCAL = "write_local"
+    EXECUTE_LOCAL = "execute_local"
+    EXECUTE_CODE = "execute_code"
+    RESEARCH_WEB = "research_web"
+    INTERACT_BROWSER = "interact_browser"
+    CONTROL_DESKTOP = "control_desktop"
+    ANALYZE_IMAGE = "analyze_image"
+    GENERATE_IMAGE = "generate_image"
+    ANALYZE_VIDEO = "analyze_video"
+    GENERATE_VIDEO = "generate_video"
+    MEMORY_OPERATION = "memory_operation"
+    SKILL_OPERATION = "skill_operation"
+    TODO_OPERATION = "todo_operation"
+    SESSION_LOOKUP = "session_lookup"
+    SCHEDULE_OPERATION = "schedule_operation"
+    DELEGATE = "delegate"
+    GIT_OPERATION = "git_operation"
+    ASK_CLARIFICATION = "ask_clarification"
+    FULL_SURFACE = "full_surface"
+
+
+@dataclass(frozen=True)
+class IntentResult:
+    intents: FrozenSet[Intent]
+    confidence: float
+    reason_code: str
+
+
+_CONCEPTUAL = re.compile(
+    r"^\s*(what\s+(?:is|are)|who\s+(?:is|are)|why\b|explain\b|define\b|"
+    r"compare\b|difference\s+between\b|how\s+(?:does|do|can|to)\b)",
+    re.IGNORECASE,
+)
+_BROWSER_ACTION = re.compile(
+    r"\b(log\s*in|sign\s*in|click|submit|fill|form|navigate|interact|checkout|purchase)\b",
+    re.IGNORECASE,
+)
+_URL = re.compile(r"https?://", re.IGNORECASE)
+
+
+def classify_intent(message: str) -> IntentResult:
+    """Classify obvious intent; unresolved requests fail open upstream.
+
+    Conceptual phrasing takes precedence over subject keywords so phrases such
+    as "what is a Git repository" do not accidentally grant execution tools.
+    """
+
+    text = (message or "").strip()
+    lower = text.lower()
+    if not text:
+        return IntentResult(frozenset({Intent.FULL_SURFACE}), 0.0, "empty")
+
+    if _CONCEPTUAL.search(text) and not re.search(
+        r"\b(current|latest|today|now|my|this\s+(?:file|repo|repository|image|screenshot))\b|https?://",
+        lower,
+    ):
+        return IntentResult(frozenset({Intent.ANSWER_ONLY}), 0.99, "conceptual")
+
+    explicit_intents: set[Intent] = set()
+    if re.search(r"\b(code[_ -]?execution|execute_code|sandboxed code)\b", lower):
+        explicit_intents.add(Intent.EXECUTE_CODE)
+    if re.search(r"\b(skill_view|skills? tool|load (?:the )?[a-z0-9_-]+ skill)\b", lower):
+        explicit_intents.add(Intent.SKILL_OPERATION)
+    if re.search(r"\b(session[_ -]?search|previous session|past conversation|session history)\b", lower):
+        explicit_intents.add(Intent.SESSION_LOOKUP)
+    if re.search(r"\b(cronjob|cron job|scheduled jobs?)\b", lower):
+        explicit_intents.add(Intent.SCHEDULE_OPERATION)
+    if re.search(r"\b(todo tool|task list)\b", lower):
+        explicit_intents.add(Intent.TODO_OPERATION)
+    if explicit_intents:
+        return IntentResult(frozenset(explicit_intents), 0.99, "explicit_tool_intent")
+
+    if re.search(
+        r"\b(computer[- _]?use|desktop control|control (?:the )?(?:desktop|computer)|"
+        r"capture (?:the )?(?:safari|chrome|browser|desktop|screen|window)|"
+        r"(?:safari|chrome) window|desktop window)\b",
+        lower,
+    ):
+        return IntentResult(frozenset({Intent.CONTROL_DESKTOP}), 0.99, "desktop_control")
+
+    if re.search(r"\b(screenshot|photo|picture|image|diagram)\b", lower):
+        if re.search(r"\b(generate|create|draw|design|make)\b", lower):
+            return IntentResult(frozenset({Intent.GENERATE_IMAGE}), 0.98, "generate_image")
+        if re.search(r"\b(review|inspect|analy[sz]e|describe|read|look at)\b", lower):
+            return IntentResult(frozenset({Intent.ANALYZE_IMAGE}), 0.98, "analyze_image")
+
+    if re.search(r"\b(video|movie|clip|animation)\b", lower):
+        if re.search(r"\b(generate|create|make|animate)\b", lower):
+            return IntentResult(frozenset({Intent.GENERATE_VIDEO}), 0.96, "generate_video")
+        if re.search(r"\b(analy[sz]e|review|describe|inspect)\b", lower):
+            return IntentResult(frozenset({Intent.ANALYZE_VIDEO}), 0.96, "analyze_video")
+
+    if _URL.search(text) and _BROWSER_ACTION.search(text):
+        return IntentResult(frozenset({Intent.INTERACT_BROWSER}), 0.99, "interactive_url")
+
+    intents: set[Intent] = set()
+    if _URL.search(text) or re.search(
+        r"\b(search|research|look\s*up|latest|current|today|news|weather|price|online)\b",
+        lower,
+    ):
+        intents.add(Intent.RESEARCH_WEB)
+    if _BROWSER_ACTION.search(text) or re.search(r"\bopen (?:the )?(?:site|website|browser)\b", lower):
+        intents.add(Intent.INTERACT_BROWSER)
+        intents.discard(Intent.RESEARCH_WEB)
+    if re.search(r"\b(read|inspect|review|search)\b.{0,30}\b(file|folder|path|repo|repository)\b", lower):
+        intents.add(Intent.READ_LOCAL)
+    if re.search(r"\b(save|write|edit|modify|patch|rename|copy|move|delete)\b", lower):
+        intents.add(Intent.WRITE_LOCAL)
+    if re.search(r"\b(run|execute|install|build|test|pytest|npm|compile|lint|shell|terminal|command)\b", lower):
+        intents.add(Intent.EXECUTE_LOCAL)
+    if re.search(r"\b(commit|push|pull|checkout|merge|git\s+diff)\b", lower):
+        intents.update({Intent.READ_LOCAL, Intent.WRITE_LOCAL, Intent.EXECUTE_LOCAL, Intent.GIT_OPERATION})
+    if re.search(r"\b(remember|store this|save this to memory)\b", lower):
+        intents.add(Intent.MEMORY_OPERATION)
+    if re.search(r"\b(previous session|past conversation|session history|where did we leave)\b", lower):
+        intents.add(Intent.SESSION_LOOKUP)
+    if re.search(r"\b(schedule|cron|remind me|every day|every week)\b", lower):
+        intents.add(Intent.SCHEDULE_OPERATION)
+    if re.search(r"\b(delegate|subagent|sub-agent)\b", lower):
+        intents.add(Intent.DELEGATE)
+
+    if intents:
+        return IntentResult(frozenset(intents), 0.95, "deterministic_actions")
+
+    if _CONCEPTUAL.search(text):
+        return IntentResult(frozenset({Intent.ANSWER_ONLY}), 0.95, "conceptual")
+
+    return IntentResult(frozenset({Intent.FULL_SURFACE}), 0.0, "unresolved")
+
+
+INTENT_TOOLSETS: dict[Intent, frozenset[str]] = {
+    Intent.READ_LOCAL: frozenset({"file"}),
+    Intent.WRITE_LOCAL: frozenset({"file"}),
+    Intent.EXECUTE_LOCAL: frozenset({"terminal"}),
+    Intent.EXECUTE_CODE: frozenset({"code_execution"}),
+    Intent.RESEARCH_WEB: frozenset({"web"}),
+    Intent.INTERACT_BROWSER: frozenset({"browser"}),
+    Intent.CONTROL_DESKTOP: frozenset({"computer_use"}),
+    Intent.ANALYZE_IMAGE: frozenset({"vision"}),
+    Intent.GENERATE_IMAGE: frozenset({"image_gen"}),
+    Intent.ANALYZE_VIDEO: frozenset({"video"}),
+    Intent.GENERATE_VIDEO: frozenset({"video_gen"}),
+    Intent.MEMORY_OPERATION: frozenset({"memory"}),
+    Intent.SKILL_OPERATION: frozenset({"skills"}),
+    Intent.TODO_OPERATION: frozenset({"todo"}),
+    Intent.SESSION_LOOKUP: frozenset({"session_search"}),
+    Intent.SCHEDULE_OPERATION: frozenset({"cronjob"}),
+    Intent.DELEGATE: frozenset({"delegation"}),
+    Intent.GIT_OPERATION: frozenset({"git"}),
+    Intent.ASK_CLARIFICATION: frozenset({"clarify"}),
+}

--- a/models.py
+++ b/models.py
@@ -1,0 +1,75 @@
+"""Typed routing decisions shared by policy, application, and diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import FrozenSet, Iterable, Optional
+
+
+class RouteAction(str, Enum):
+    """How the router should shape the tool surface."""
+
+    NARROW = "narrow"
+    FULL = "full"
+    NO_TOOLS = "no_tools"
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    """An explicit, auditable routing result.
+
+    ``FULL`` represents uncertainty/fail-open. ``NO_TOOLS`` is an intentional
+    answer-only route and is never overloaded as an error signal.
+    """
+
+    action: RouteAction
+    toolsets: FrozenSet[str] = field(default_factory=frozenset)
+    confidence: Optional[float] = None
+    reason_code: str = ""
+    source: str = "deterministic"
+
+    def __post_init__(self) -> None:
+        if self.action is RouteAction.NARROW and not self.toolsets:
+            raise ValueError("a narrow route requires at least one toolset")
+        if self.action is not RouteAction.NARROW and self.toolsets:
+            raise ValueError("only narrow routes may contain toolsets")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+
+    @classmethod
+    def narrow(
+        cls,
+        toolsets: Iterable[str],
+        *,
+        confidence: Optional[float],
+        reason_code: str,
+        source: str = "deterministic",
+    ) -> "RouteDecision":
+        return cls(
+            RouteAction.NARROW,
+            frozenset(str(name).strip() for name in toolsets if str(name).strip()),
+            confidence,
+            reason_code,
+            source,
+        )
+
+    @classmethod
+    def full(
+        cls,
+        *,
+        reason_code: str,
+        confidence: Optional[float] = None,
+        source: str = "policy",
+    ) -> "RouteDecision":
+        return cls(RouteAction.FULL, confidence=confidence, reason_code=reason_code, source=source)
+
+    @classmethod
+    def no_tools(
+        cls,
+        *,
+        reason_code: str,
+        confidence: Optional[float] = 1.0,
+        source: str = "deterministic",
+    ) -> "RouteDecision":
+        return cls(RouteAction.NO_TOOLS, confidence=confidence, reason_code=reason_code, source=source)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,13 +1,15 @@
 name: hermes-token-router
-version: 0.1.0
-description: "Hermes Tool Router — pre-turn toolset prediction with request_toolset recovery. Narrows tool schemas to reduce prompt token overhead, then expands safely on demand."
+version: 0.2.0-rc1
+description: "First-turn, session-sticky Hermes tool-surface routing with monotonic recovery."
 author: "Jonathan Rivera"
 license: MIT
 kind: standalone
 requires_env: []
 provides_hooks:
-  - pre_turn_context_build
   - pre_llm_call
   - post_tool_call
+  - on_session_end
+provides_middleware:
+  - tool_request
 provides_tools:
   - request_toolset

--- a/policy.py
+++ b/policy.py
@@ -7,12 +7,16 @@ import logging
 import os
 import re
 import time
-from typing import Any, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 try:
     from .config import PLUGIN_NAME
+    from .classifier import call_with_hard_timeout
+    from .intent import INTENT_TOOLSETS, Intent, classify_intent
 except ImportError:  # pragma: no cover - direct loader fallback
     from config import PLUGIN_NAME
+    from classifier import call_with_hard_timeout
+    from intent import INTENT_TOOLSETS, Intent, classify_intent
 
 logger = logging.getLogger(__name__)
 
@@ -78,21 +82,27 @@ PLAIN_ANSWER_RE = re.compile(
 ROUTER_SYSTEM_PROMPT = """You are a tool-router classifier. Given a user message and a list of available toolsets with descriptions, predict which toolsets the AI assistant will need to respond.
 
 Rules:
-1. Return ONLY a JSON object with a single key "toolsets" containing an array of toolset names.
-2. Include ONLY toolsets directly relevant to the user's request.
-3. Do not include terminal, file, or web unless the request actually needs them.
-4. For ordinary questions that can be answered without tools, return an empty array.
-5. If the message is ambiguous or uncertain, return "all" as the only element.
-6. Be conservative; only include toolsets you are confident are needed.
+1. Return ONLY JSON: {"toolsets": ["name"], "confidence": 0.0}.
+2. confidence must be a number from 0.0 to 1.0.
+3. Include ONLY toolsets directly relevant to the user's request.
+4. Do not include terminal, file, or web unless the request actually needs them.
+5. For ordinary questions that can be answered without tools, return an empty array.
+6. If the message is ambiguous or uncertain, return "all" as the only toolset.
+7. Be conservative; only include toolsets you are confident are needed.
 Example response:
-{{"toolsets": ["terminal", "file", "web", "git"]}}
+{{"toolsets": ["terminal", "file"], "confidence": 0.96}}
 
 Available toolsets:
 {toolset_descriptions}
 
 User message: {user_message}
 """
-def _get_router_client(router_model: str, router_provider: str = "deepseek"):
+def _get_router_client(
+    router_model: str,
+    router_provider: str = "deepseek",
+    custom_base_url: str = "",
+    custom_api_key_env: str = "",
+):
     """Obtain an OpenAI-compatible client for the router.
 
     Supports:
@@ -132,6 +142,26 @@ def _get_router_client(router_model: str, router_provider: str = "deepseek"):
                     "HTTP-Referer": "https://github.com/hermes-agent/hermes-token-router",
                     "X-Title": "Hermes Tool Router",
                 },
+            )
+            return client, router_model
+
+        elif router_provider == "custom":
+            if not custom_base_url:
+                logger.debug("%s: custom classifier requires base_url", PLUGIN_NAME)
+                return None, None
+            api_key = os.environ.get(custom_api_key_env, "") if custom_api_key_env else "local"
+            if custom_api_key_env and not api_key:
+                logger.debug(
+                    "%s: custom classifier key env %s is unset",
+                    PLUGIN_NAME,
+                    custom_api_key_env,
+                )
+                return None, None
+            client = OpenAI(
+                api_key=api_key,
+                base_url=custom_base_url,
+                timeout=2,
+                max_retries=0,
             )
             return client, router_model
 
@@ -184,6 +214,17 @@ def _predict_toolsets_by_rules(
     if not lowered:
         return None, "empty"
 
+    intent_result = classify_intent(text)
+    if intent_result.intents == frozenset({Intent.ANSWER_ONLY}):
+        return set(), f"intent:{intent_result.reason_code}"
+    if Intent.FULL_SURFACE not in intent_result.intents:
+        intent_toolsets: Set[str] = set()
+        for intent in intent_result.intents:
+            intent_toolsets.update(INTENT_TOOLSETS.get(intent, frozenset()))
+        intent_toolsets &= available_toolsets
+        if intent_toolsets:
+            return intent_toolsets, f"intent:{intent_result.reason_code}"
+
     matched: Set[str] = set()
     matched_rules = 0
     for pattern, toolsets in TOOLSET_INTENT_RULES:
@@ -206,10 +247,10 @@ def _predict_toolsets_by_rules(
         return set(), "plain_default"
 
     return None, "needs_llm"
-def _extract_confidence(result: Any) -> float:
-    """Extract confidence from router output; return 1.0 when missing."""
+def _extract_confidence(result: Any) -> Optional[float]:
+    """Extract confidence from router output; missing confidence is unknown."""
     if not isinstance(result, dict):
-        return 1.0
+        return None
 
     for key in ("confidence", "probability", "prob", "score", "confidence_score"):
         raw = result.get(key)
@@ -235,13 +276,16 @@ def _extract_confidence(result: Any) -> float:
 
         return parsed
 
-    return 1.0
+    return None
 def _predict_toolsets_via_llm(
     user_message: str,
     available_toolsets: Set[str],
     router_model: str,
     confidence_threshold: float,
     router_provider: str = "deepseek",
+    hard_timeout_seconds: float = 1.2,
+    custom_base_url: str = "",
+    custom_api_key_env: str = "",
 ) -> Optional[Set[str]]:
     """Use the router model to predict which toolsets are needed.
 
@@ -249,7 +293,12 @@ def _predict_toolsets_via_llm(
     On any error, returns None for safe fallback.
     """
     try:
-        client, model = _get_router_client(router_model, router_provider)
+        client, model = _get_router_client(
+            router_model,
+            router_provider,
+            custom_base_url,
+            custom_api_key_env,
+        )
         if client is None:
             logger.debug(
                 "%s: router client unavailable — full set fallback",
@@ -273,30 +322,29 @@ def _predict_toolsets_via_llm(
             model,
         )
 
-        # Wrap in a thread with a hard timeout — prevent any hang
-        from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
-        with ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(
-                client.chat.completions.create,
+        def invoke_classifier():
+            return client.chat.completions.create(
                 model=model,
                 messages=[{"role": "system", "content": prompt}],
                 temperature=0.0,
                 max_tokens=200,
             )
-            try:
-                response = future.result(timeout=8)
-            except FutureTimeoutError:
+
+        try:
+            completed, response = call_with_hard_timeout(invoke_classifier, hard_timeout_seconds)
+            if not completed or response is None:
                 logger.warning(
-                    "%s: router prediction timed out after 8s — full set fallback",
+                    "%s: router prediction timed out after %.2fs — full set fallback",
                     PLUGIN_NAME,
+                    hard_timeout_seconds,
                 )
                 return None
-            except Exception as thread_exc:
-                logger.warning(
-                    "%s: router API call failed: %s — full set fallback",
-                    PLUGIN_NAME, thread_exc,
-                )
-                return None
+        except Exception as thread_exc:
+            logger.warning(
+                "%s: router API call failed: %s — full set fallback",
+                PLUGIN_NAME, thread_exc,
+            )
+            return None
         elapsed = time.monotonic() - start
 
         content = response.choices[0].message.content or ""
@@ -321,6 +369,9 @@ def _predict_toolsets_via_llm(
         predicted_list = result.get("toolsets", [])
 
         confidence = _extract_confidence(result)
+        if confidence is None:
+            logger.info("%s: router omitted confidence; keeping full toolset", PLUGIN_NAME)
+            return None
         if confidence < confidence_threshold:
             logger.info(
                 "%s: router confidence %.3f below threshold %.3f; keeping full toolset",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hermes-tool-router"
+version = "0.2.0rc1"
+description = "First-turn, session-sticky tool-surface router for Hermes Agent"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [{name = "Jonathan Rivera"}]
+dependencies = ["PyYAML>=6.0"]
+
+[project.optional-dependencies]
+classifier = ["openai>=1.0.0"]
+dev = ["pytest>=8", "ruff>=0.6", "build>=1.2"]
+
+[project.entry-points."hermes_agent.plugins"]
+hermes-token-router = "hermes_token_router_plugin:register"
+
+[tool.setuptools]
+packages = ["hermes_token_router_plugin"]
+package-dir = {hermes_token_router_plugin = "."}
+
+[tool.setuptools.package-data]
+hermes_token_router_plugin = ["config.yaml", "plugin.yaml"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"tests/*.py" = ["E402"]
+"benchmarks/run.py" = ["E402"]

--- a/registry_adapter.py
+++ b/registry_adapter.py
@@ -1,0 +1,35 @@
+"""Public-API adapter for Hermes's dynamic tool registry."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+class RegistryAdapter:
+    """Keep version-specific registry access behind a small tested boundary."""
+
+    def __init__(self, registry: Any):
+        self._registry = registry
+
+    @classmethod
+    def live(cls) -> "RegistryAdapter":
+        from tools.registry import registry
+
+        return cls(registry)
+
+    def available_toolsets(self) -> set[str]:
+        return set(self._registry.get_registered_toolset_names())
+
+    def tools_for_toolset(self, name: str) -> set[str]:
+        return set(self._registry.get_tool_names_for_toolset(name) or [])
+
+    def toolset_for_tool(self, tool_name: str) -> str | None:
+        entry = self._registry.get_entry(tool_name)
+        return str(entry.toolset) if entry is not None and getattr(entry, "toolset", None) else None
+
+    def definitions_for_tools(self, names: Iterable[str]) -> list[dict]:
+        return list(self._registry.get_definitions(set(names), quiet=True) or [])
+
+    def resolve_alias(self, name: str) -> str:
+        target = self._registry.get_toolset_alias_target(name)
+        return str(target or name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml>=6.0
+# Optional; only required when classifier.enabled is true.
 openai>=1.0.0

--- a/scripts/live_router_evaluator.py
+++ b/scripts/live_router_evaluator.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Paired live Edith evaluator for hermes-token-router."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+SESSION_RE = re.compile(r"Session:\s+([A-Za-z0-9_]+)")
+ROUTE_RE = re.compile(r"predicted_toolsets=\[([^]]*)\]")
+TOOL_RE = re.compile(r"tool ([A-Za-z0-9_]+) completed", re.IGNORECASE)
+FIRST_INPUT_RE = re.compile(r"API call #1:.*?\bin=(\d+)")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", default="edith")
+    parser.add_argument("--cases", type=Path, default=Path(__file__).resolve().parents[1] / "benchmarks/live_cases.json")
+    parser.add_argument("--state-db", type=Path, default=Path.home() / ".hermes/profiles/edith/state.db")
+    parser.add_argument("--agent-log", type=Path, default=Path.home() / ".hermes/profiles/edith/logs/agent.log")
+    parser.add_argument("--output", type=Path, default=Path(__file__).resolve().parents[1] / "runs/live_router_eval.json")
+    parser.add_argument("--timeout", type=int, default=180)
+    parser.add_argument("--baseline-cases", default="answer_only,terminal,web")
+    parser.add_argument("--max-cases", type=int, default=0)
+    return parser.parse_args()
+
+
+def run_case(profile: str, case: dict[str, Any], routed: bool, timeout: int) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["HERMES_TOKEN_ROUTER_ENABLED"] = "true" if routed else "false"
+    prompt = case["prompt"].replace(
+        "{{HERMES_PYTHON}}",
+        str(Path.home() / ".hermes/hermes-agent/.venv/bin/python"),
+    )
+    started = time.monotonic()
+    proc = subprocess.run(
+        ["hermes", "--profile", profile, "chat", "-q", prompt],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+        timeout=timeout,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    match = SESSION_RE.search(proc.stdout)
+    return {
+        "case_id": case["id"],
+        "mode": "routed" if routed else "baseline",
+        "returncode": proc.returncode,
+        "session_id": match.group(1) if match else "",
+        "elapsed_seconds": round(elapsed, 3),
+        "stdout_tail": proc.stdout[-2000:],
+    }
+
+
+def session_metrics(db_path: Path, session_id: str) -> dict[str, Any]:
+    if not session_id:
+        return {}
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """SELECT input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                      tool_call_count, api_call_count, estimated_cost_usd
+               FROM sessions WHERE id = ?""",
+            (session_id,),
+        ).fetchone()
+        answer = conn.execute(
+            "SELECT content FROM messages WHERE session_id = ? AND role = 'assistant' ORDER BY id DESC LIMIT 1",
+            (session_id,),
+        ).fetchone()
+    result = dict(row) if row else {}
+    result["answer"] = answer[0] if answer else ""
+    return result
+
+
+def log_metrics(log_text: str, session_id: str) -> dict[str, Any]:
+    lines = [line for line in log_text.splitlines() if session_id and session_id in line]
+    joined = "\n".join(lines)
+    route_match = ROUTE_RE.search(joined)
+    route = []
+    if route_match:
+        route = re.findall(r"['\"]([^'\"]+)['\"]", route_match.group(1))
+    tools = sorted(set(TOOL_RE.findall(joined)))
+    errors = [line for line in lines if " ERROR " in line or "returned error" in line]
+    input_match = FIRST_INPUT_RE.search(joined)
+    return {
+        "predicted_toolsets": route,
+        "completed_tools": tools,
+        "errors": errors,
+        "first_request_input_tokens": int(input_match.group(1)) if input_match else None,
+    }
+
+
+def evaluate_case(case: dict[str, Any], run: dict[str, Any]) -> None:
+    expected_sets = set(case.get("expected_toolsets", []))
+    predicted_sets = set(run.get("predicted_toolsets", []))
+    expected_tools = set(case.get("expected_tools", []))
+    completed_tools = set(run.get("completed_tools", []))
+    answer = run.get("answer", "")
+    run["route_recall_ok"] = expected_sets.issubset(predicted_sets)
+    run["route_exact_ok"] = expected_sets == predicted_sets
+    run["tool_success_ok"] = not expected_tools or bool(expected_tools & completed_tools)
+    run["answer_check_ok"] = all(text.lower() in answer.lower() for text in case.get("must_contain", []))
+    run["case_passed"] = bool(
+        run.get("returncode") == 0
+        and run.get("session_id")
+        and run["route_recall_ok"]
+        and run["tool_success_ok"]
+        and run["answer_check_ok"]
+        and not run.get("errors")
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    cases = json.loads(args.cases.read_text())
+    if args.max_cases > 0:
+        cases = cases[: args.max_cases]
+    baseline_ids = {item.strip() for item in args.baseline_cases.split(",") if item.strip()}
+    Path("/tmp/router-edith-probe.txt").write_text("EDITH_ROUTER_PROBE_OK\n")
+
+    results: list[dict[str, Any]] = []
+    for case in cases:
+        routed_run = run_case(args.profile, case, True, args.timeout)
+        time.sleep(0.2)
+        routed_run.update(session_metrics(args.state_db, routed_run["session_id"]))
+        routed_run.update(log_metrics(args.agent_log.read_text(errors="replace"), routed_run["session_id"]))
+        evaluate_case(case, routed_run)
+        results.append(routed_run)
+
+        if case["id"] in baseline_ids:
+            baseline_run = run_case(args.profile, case, False, args.timeout)
+            time.sleep(0.2)
+            baseline_run.update(session_metrics(args.state_db, baseline_run["session_id"]))
+            baseline_run.update(log_metrics(args.agent_log.read_text(errors="replace"), baseline_run["session_id"]))
+            results.append(baseline_run)
+
+    routed = [row for row in results if row["mode"] == "routed"]
+    pairs: list[dict[str, Any]] = []
+    for case_id in baseline_ids:
+        route_row = next((row for row in results if row["case_id"] == case_id and row["mode"] == "routed"), None)
+        base_row = next((row for row in results if row["case_id"] == case_id and row["mode"] == "baseline"), None)
+        base_tokens = base_row.get("first_request_input_tokens") if base_row else None
+        route_tokens = route_row.get("first_request_input_tokens") if route_row else None
+        if route_row and base_row and base_tokens and route_tokens:
+            reduction = 1.0 - route_tokens / base_tokens
+            pairs.append(
+                {
+                    "case_id": case_id,
+                    "routed_first_request_tokens": route_tokens,
+                    "baseline_first_request_tokens": base_tokens,
+                    "token_reduction": reduction,
+                }
+            )
+
+    count = max(1, len(routed))
+    route_recall = sum(bool(row.get("route_recall_ok")) for row in routed) / count
+    route_exact = sum(bool(row.get("route_exact_ok")) for row in routed) / count
+    tool_success = sum(bool(row.get("tool_success_ok")) for row in routed) / count
+    answer_accuracy = sum(bool(row.get("answer_check_ok")) for row in routed) / count
+    pass_rate = sum(bool(row.get("case_passed")) for row in routed) / count
+    avg_reduction = sum(pair["token_reduction"] for pair in pairs) / len(pairs) if pairs else 0.0
+    score = 40 * route_recall + 20 * tool_success + 15 * answer_accuracy + 10 * route_exact + 15 * max(0.0, avg_reduction)
+    metrics = {
+        "cases": len(routed),
+        "route_recall": route_recall,
+        "route_exact_accuracy": route_exact,
+        "tool_success_rate": tool_success,
+        "answer_accuracy": answer_accuracy,
+        "case_pass_rate": pass_rate,
+        "paired_average_token_reduction": avg_reduction,
+        "paired_cases": pairs,
+        "total_elapsed_seconds": sum(row["elapsed_seconds"] for row in results),
+    }
+    payload = {
+        "score": round(score, 6),
+        "accepted": route_recall == 1.0 and tool_success >= 0.9 and answer_accuracy >= 0.9,
+        "reason": f"live Edith router evaluation: {sum(bool(r.get('case_passed')) for r in routed)}/{len(routed)} cases passed",
+        "metrics": metrics,
+        "results": results,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps({key: value for key, value in payload.items() if key != "results"}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/measure_schema_tokens.py
+++ b/scripts/measure_schema_tokens.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Measure live Hermes tool-schema request estimates with provider-aware code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hermes-source", type=Path, required=True)
+    parser.add_argument("--toolsets", default="web")
+    args = parser.parse_args()
+    sys.path.insert(0, str(args.hermes_source.resolve()))
+
+    import model_tools
+    from agent.model_metadata import estimate_request_tokens_rough
+
+    selected = [name.strip() for name in args.toolsets.split(",") if name.strip()]
+    full_defs = model_tools.get_tool_definitions(quiet_mode=True)
+    routed_defs = model_tools.get_tool_definitions(enabled_toolsets=selected, quiet_mode=True)
+    messages = [{"role": "user", "content": "schema measurement"}]
+    full_tokens = estimate_request_tokens_rough(messages, tools=full_defs or None)
+    routed_tokens = estimate_request_tokens_rough(messages, tools=routed_defs or None)
+    reduction = 1.0 - (routed_tokens / full_tokens) if full_tokens else 0.0
+    print(json.dumps({
+        "full_tools": len(full_defs),
+        "routed_tools": len(routed_defs),
+        "toolsets": selected,
+        "full_request_tokens": full_tokens,
+        "routed_request_tokens": routed_tokens,
+        "estimated_reduction": reduction,
+    }, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/state.py
+++ b/state.py
@@ -5,14 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional, Set
 
-try:
-    from .config import PLUGIN_NAME
-except ImportError:  # pragma: no cover - direct loader fallback
-    from config import PLUGIN_NAME
-
 logger = logging.getLogger(__name__)
 
 _agent_ref: Any = None
+_agent_refs: Dict[str, Any] = {}
 
 def _get_agent_from_stack() -> Any:
     """Walk the call stack to find the agent object.
@@ -50,6 +46,29 @@ class RouterState:
         self._retry_pending: bool = False
         self.routed_turn_id: Optional[str] = None
         self.routed_source: Optional[str] = None
+        self.initial_route_applied: bool = False
+        self.initial_toolsets: Set[str] = set()
+        self.active_toolsets: Set[str] = set()
+        self.registry_generation: int = 0
+        self.expansion_count: int = 0
+
+    def set_initial_surface(self, toolsets: Set[str]) -> bool:
+        """Set the routed surface once; later calls cannot shrink or replace it."""
+        if self.initial_route_applied:
+            return False
+        selected = set(toolsets)
+        self.initial_route_applied = True
+        self.initial_toolsets = selected
+        self.active_toolsets = set(selected)
+        return True
+
+    def expand_surface(self, toolsets: Set[str]) -> Set[str]:
+        """Monotonically add toolsets and return the names newly activated."""
+        additions = set(toolsets) - self.active_toolsets
+        if additions:
+            self.active_toolsets.update(additions)
+            self.expansion_count += 1
+        return additions
 
     def reset(self):
         self.active = False
@@ -63,6 +82,11 @@ class RouterState:
         self._retry_pending = False
         self.routed_turn_id = None
         self.routed_source = None
+        self.initial_route_applied = False
+        self.initial_toolsets = set()
+        self.active_toolsets = set()
+        self.registry_generation = 0
+        self.expansion_count = 0
 
 _router_state = RouterState()
 
@@ -82,13 +106,30 @@ def _get_router_state(agent: Any = None) -> RouterState:
     if _agent_ref is not None:
         return _get_router_state(_agent_ref)
     return _router_state
-
-def _store_agent_ref(agent: Any) -> None:
-    """Store the agent reference globally for subsequent hook calls."""
+def _store_agent_ref(agent: Any, session_id: Optional[str] = None) -> None:
+    """Store a live agent under its session identity for concurrent safety."""
     global _agent_ref
     _agent_ref = agent
+    key = session_id or getattr(agent, "session_id", None)
+    if key:
+        _agent_refs[str(key)] = agent
 
 
-def _get_agent_ref() -> Any:
-    """Return the best-effort cached live agent reference."""
-    return _agent_ref
+def _drop_agent_ref(session_id: str) -> None:
+    """Release a finished session's cached agent reference."""
+    global _agent_ref
+    removed = _agent_refs.pop(str(session_id), None)
+    if removed is _agent_ref:
+        _agent_ref = None
+
+
+def _get_agent_ref(session_id: Optional[str] = None) -> Any:
+    """Resolve by session; ambiguous global lookup deliberately returns None."""
+    if session_id:
+        return _agent_refs.get(str(session_id))
+    unique = {id(agent): agent for agent in _agent_refs.values()}
+    if len(unique) == 1:
+        return next(iter(unique.values()))
+    if not unique:
+        return _agent_ref
+    return None

--- a/tests/smoke_hardening.py
+++ b/tests/smoke_hardening.py
@@ -109,9 +109,6 @@ class _FakeRegistry:
     def get_entry(self, name):
         return self.entries.get(name)
 
-    def _snapshot_entries(self):
-        return list(self.entries.values())
-
 
 _FAKE_REGISTRY = _FakeRegistry()
 _fake_registry_module = types.ModuleType("tools.registry")
@@ -190,7 +187,8 @@ def _assert_route(prompt: str, expected_toolsets: set[str]) -> None:
 def test_recovery_schema_and_core_hook_surface():
     assert "request_toolset" == plugin.RECOVERY_TOOL_NAME
     assert plugin.RECOVERY_TOOL_SCHEMA["parameters"].get("additionalProperties") is False
-    assert "enum" in plugin.RECOVERY_TOOL_SCHEMA["parameters"]["properties"]["toolset"]
+    assert "toolsets" in plugin.RECOVERY_TOOL_SCHEMA["parameters"]["properties"]
+    assert plugin.RECOVERY_TOOL_SCHEMA["parameters"]["properties"]["toolsets"]["items"] == {"type": "string"}
     assert "tool_name" in plugin.RECOVERY_TOOL_SCHEMA["parameters"]["properties"]
     assert callable(plugin.pre_turn_context_build)
     assert callable(plugin.pre_llm_call)
@@ -200,7 +198,7 @@ def test_deterministic_routes():
     cases = [
         ("what is photosynthesis", {"request_toolset"}),
         ("check the hermes subreddit", {"web", "browser", "request_toolset"}),
-        ("open https://example.com and click the first link", {"web", "browser", "request_toolset"}),
+        ("open https://example.com and click the first link", {"browser", "request_toolset"}),
         ("latest weather today", {"web", "request_toolset"}),
         ("read this file", {"file", "request_toolset"}),
         ("run the shell test command", {"terminal", "request_toolset"}),
@@ -214,6 +212,24 @@ def test_deterministic_routes():
     ]
     for prompt, expected in cases:
         _assert_route(prompt, expected)
+
+
+def test_late_pre_llm_compatibility_routes_before_request_without_explicit_agent():
+    agent = _FakeAgent()
+    agent._current_turn_id = "late-turn"
+
+    def invoke_from_turn_context_stack():
+        # The local variable name intentionally matches Hermes build_turn_context.
+        return plugin.pre_llm_call(
+            session_id=agent.session_id,
+            turn_id=agent._current_turn_id,
+            user_message="latest weather today",
+            conversation_history=[],
+            is_first_turn=True,
+        )
+
+    invoke_from_turn_context_stack()
+    assert _exposed_toolsets(agent) == {"web", "request_toolset"}
 
 
 def test_pre_llm_call_skips_after_core_hook_routed_turn():
@@ -246,6 +262,18 @@ def test_pre_llm_call_skips_after_core_hook_routed_turn():
     assert agent.valid_tool_names == before_names
 
 
+def test_tool_request_middleware_expands_registered_pruned_tool_before_validation():
+    agent = _route("what is photosynthesis")
+    assert "git_status" not in agent.valid_tool_names
+    result = plugin.tool_request_middleware(
+        session_id=agent.session_id,
+        tool_name="git_status",
+        args={"short": True},
+    )
+    assert result == {"args": {"short": True}, "router_recovered": "git"}
+    assert "git_status" in agent.valid_tool_names
+
+
 def test_request_toolset_git_expansion():
     agent = _route("what is photosynthesis")
     assert _exposed_toolsets(agent) == {"request_toolset"}
@@ -262,6 +290,30 @@ def test_request_toolset_unknown_suggestion():
     assert response["error"].startswith("unknown toolset")
     assert "suggestions" in response
     assert "git" in response["suggestions"]
+
+
+def test_first_turn_surface_is_sticky_and_does_not_shrink_or_reclassify():
+    agent = _FakeAgent()
+    agent._current_turn_id = "turn-one"
+    plugin.pre_turn_context_build(
+        agent=agent,
+        turn_id="turn-one",
+        user_message="latest weather today",
+        conversation_history=[],
+        is_first_turn=True,
+    )
+    first_names = set(agent.valid_tool_names)
+    assert "web_search" in first_names
+
+    agent._current_turn_id = "turn-two"
+    plugin.pre_turn_context_build(
+        agent=agent,
+        turn_id="turn-two",
+        user_message="read this file",
+        conversation_history=[{"role": "user", "content": "latest weather today"}],
+        is_first_turn=False,
+    )
+    assert agent.valid_tool_names == first_names
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_scoring.py
+++ b/tests/test_benchmark_scoring.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "benchmarks" / "scoring.py"
+spec = importlib.util.spec_from_file_location("router_benchmark_scoring", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules["router_benchmark_scoring"] = module
+spec.loader.exec_module(module)
+
+
+def test_scoring_computes_required_recall_and_precision():
+    records = [
+        ({"web"}, {"web"}),
+        ({"file", "terminal"}, {"file"}),
+        (set(), set()),
+    ]
+    result = module.score_routes(records)
+    assert result["required_recall"] == 2 / 3
+    assert result["toolset_precision"] == 1.0
+    assert result["exact_set_accuracy"] == 2 / 3

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_classifier_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_classifier_test.classifier import call_with_hard_timeout, parse_classifier_output
+from hermes_tool_router_classifier_test.models import RouteAction
+
+
+def test_missing_confidence_fails_open():
+    decision = parse_classifier_output('{"action":"narrow","toolsets":["web"]}', {"web"}, 0.9)
+    assert decision.action is RouteAction.FULL
+    assert decision.reason_code == "missing_confidence"
+
+
+def test_low_confidence_and_unknown_toolsets_fail_open():
+    low = parse_classifier_output('{"action":"narrow","toolsets":["web"],"confidence":0.5}', {"web"}, 0.9)
+    unknown = parse_classifier_output('{"action":"narrow","toolsets":["magic"],"confidence":0.99}', {"web"}, 0.9)
+    assert low.action is RouteAction.FULL
+    assert unknown.action is RouteAction.FULL
+
+
+def test_valid_structured_output_narrows():
+    decision = parse_classifier_output(
+        '```json\n{"action":"narrow","toolsets":["web"],"confidence":0.96,"reason_code":"fresh"}\n```',
+        {"web", "file"},
+        0.9,
+    )
+    assert decision.action is RouteAction.NARROW
+    assert decision.toolsets == frozenset({"web"})
+    assert decision.confidence == 0.96
+
+
+def test_malformed_output_fails_open():
+    assert parse_classifier_output("not json", {"web"}, 0.9).action is RouteAction.FULL
+
+
+def test_hard_timeout_returns_without_waiting_for_hung_worker():
+    import time
+
+    started = time.monotonic()
+    completed, value = call_with_hard_timeout(lambda: (time.sleep(0.5), "late")[1], 0.03)
+    elapsed = time.monotonic() - started
+    assert completed is False
+    assert value is None
+    assert elapsed < 0.15

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_compat_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_compat_test.compat import CompatibilityMode, detect_compatibility
+
+
+def test_compatibility_modes_are_explicit():
+    assert detect_compatibility({"pre_tool_surface_build", "on_unavailable_tool_call"}) is CompatibilityMode.PRODUCTION
+    assert detect_compatibility({"pre_turn_context_build"}) is CompatibilityMode.REDUCED_SAFETY
+    assert detect_compatibility({"pre_llm_call"}) is CompatibilityMode.LATE_COMPATIBILITY
+    assert detect_compatibility(set()) is CompatibilityMode.UNSUPPORTED_FOR_TOKEN_SAVINGS

--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_config_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_config_test.config import _get_profile_config, _is_classifier_enabled
+
+
+def test_profile_resolution_never_selects_first_enabled_profile_when_identity_unknown(monkeypatch):
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_ACTIVE_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    cfg = {
+        "global": {"enabled": False},
+        "profiles": {
+            "alpha": {"enabled": True},
+            "beta": {"enabled": True},
+        },
+    }
+    resolved = _get_profile_config(cfg)
+    assert resolved == {"enabled": False, "_profile_name": "default"}
+
+
+def test_explicit_profile_is_respected(monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE", "beta")
+    cfg = {"global": {"enabled": False}, "profiles": {"beta": {"enabled": True, "floor_toolsets": []}}}
+    resolved = _get_profile_config(cfg)
+    assert resolved["enabled"] is True
+    assert resolved["_profile_name"] == "beta"
+
+
+def test_process_override_can_disable_router_for_ab_evaluation(monkeypatch):
+    from hermes_tool_router_config_test.config import _is_router_active
+
+    monkeypatch.setenv("HERMES_PROFILE", "edith")
+    monkeypatch.setenv("HERMES_TOKEN_ROUTER_ENABLED", "false")
+    assert _is_router_active({"profiles": {"edith": {"enabled": True}}}) is False
+
+
+def test_classifier_is_opt_in():
+    assert _is_classifier_enabled({}) is False
+    assert _is_classifier_enabled({"classifier": {"enabled": False}}) is False
+    assert _is_classifier_enabled({"classifier": {"enabled": True}}) is True
+
+
+def test_classifier_model_and_provider_use_nested_v2_config():
+    from hermes_tool_router_config_test.config import (
+        _get_classifier_connection,
+        _get_router_model,
+        _get_router_provider,
+    )
+
+    cfg = {
+        "classifier": {
+            "provider": "custom",
+            "model": "router-local",
+            "base_url": "http://127.0.0.1:1234/v1",
+            "api_key_env": "LOCAL_ROUTER_KEY",
+        }
+    }
+    assert _get_router_provider(cfg) == "custom"
+    assert _get_router_model(cfg) == "router-local"
+    assert _get_classifier_connection(cfg) == (
+        "http://127.0.0.1:1234/v1",
+        "LOCAL_ROUTER_KEY",
+    )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_diagnostics_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_diagnostics_test.compat import CompatibilityMode
+from hermes_tool_router_diagnostics_test.diagnostics import build_report
+
+
+def test_diagnostic_report_reports_late_hook_savings_with_middleware_recovery():
+    report = build_report(
+        hooks={"pre_llm_call"},
+        middleware={"tool_request"},
+        toolsets={"web", "file"},
+        profile_name="default",
+        enabled=True,
+    )
+    assert report["compatibility_mode"] == CompatibilityMode.LATE_COMPATIBILITY.value
+    assert report["first_turn_savings_available"] is True
+    assert report["preflight_routing_available"] is False
+    assert report["automatic_recovery_available"] is True

--- a/tests/test_intent.py
+++ b/tests/test_intent.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_intent_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_intent_test.intent import Intent, classify_intent
+
+
+def test_conceptual_keyword_collisions_do_not_load_tools():
+    for prompt in (
+        "Explain how to open a file in Python",
+        "What is a Git repository?",
+        "Compare video codecs",
+    ):
+        result = classify_intent(prompt)
+        assert result.intents == frozenset({Intent.ANSWER_ONLY}), prompt
+
+
+def test_url_summary_uses_web_but_interaction_uses_browser():
+    assert classify_intent("Summarize https://example.com").intents == frozenset({Intent.RESEARCH_WEB})
+    assert classify_intent("Log into https://example.com and submit the form").intents == frozenset({Intent.INTERACT_BROWSER})
+
+
+def test_media_analysis_is_not_confused_with_browser_or_generation():
+    assert classify_intent("Review this screenshot").intents == frozenset({Intent.ANALYZE_IMAGE})
+    assert classify_intent("Generate a logo image").intents == frozenset({Intent.GENERATE_IMAGE})
+
+
+def test_desktop_window_capture_routes_to_computer_use():
+    result = classify_intent("Capture the Safari window and tell me what is open")
+    assert result.intents == frozenset({Intent.CONTROL_DESKTOP})
+
+
+def test_explicit_tool_intents_beat_generic_action_words():
+    cases = {
+        "Load the hermes-agent skill before answering, then return the CLI command.": Intent.SKILL_OPERATION,
+        "Use the cronjob tool to list scheduled jobs.": Intent.SCHEDULE_OPERATION,
+        "Use session search to find the previous session where Tampa weather was tested.": Intent.SESSION_LOOKUP,
+        "Use the sandboxed code_execution tool, not terminal, to calculate 7 times 9.": Intent.EXECUTE_CODE,
+        "Use the todo tool to create a two-item task list.": Intent.TODO_OPERATION,
+        "Use computer_use with action list_apps.": Intent.CONTROL_DESKTOP,
+    }
+    for prompt, expected in cases.items():
+        assert classify_intent(prompt).intents == frozenset({expected}), prompt
+
+
+def test_multi_intent_requests_return_union():
+    result = classify_intent("Search the latest release notes, save them to a file, then run the tests")
+    assert Intent.RESEARCH_WEB in result.intents
+    assert Intent.WRITE_LOCAL in result.intents
+    assert Intent.EXECUTE_LOCAL in result.intents

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_models_test"
+spec = importlib.util.spec_from_file_location(
+    PKG,
+    ROOT / "__init__.py",
+    submodule_search_locations=[str(ROOT)],
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+from hermes_tool_router_models_test.models import RouteAction, RouteDecision
+
+
+def test_route_decision_distinguishes_no_tools_from_full_fallback():
+    no_tools = RouteDecision.no_tools(reason_code="answer_only")
+    full = RouteDecision.full(reason_code="uncertain")
+
+    assert no_tools.action is RouteAction.NO_TOOLS
+    assert full.action is RouteAction.FULL
+    assert no_tools != full
+
+
+def test_narrow_route_requires_at_least_one_toolset():
+    try:
+        RouteDecision.narrow(set(), confidence=0.9, reason_code="bad")
+    except ValueError as exc:
+        assert "toolset" in str(exc).lower()
+    else:
+        raise AssertionError("empty narrow route must be rejected")
+
+
+def test_missing_confidence_is_not_treated_as_perfect_confidence():
+    decision = RouteDecision.full(reason_code="missing_confidence")
+    assert decision.confidence is None

--- a/tests/test_policy_v2.py
+++ b/tests/test_policy_v2.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_policy_v2_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_policy_v2_test.policy import _extract_confidence, _predict_toolsets_by_rules
+
+
+AVAILABLE = {"web", "browser", "file", "terminal", "vision", "image_gen", "video", "video_gen"}
+
+
+def test_policy_does_not_route_conceptual_keyword_collisions_to_tools():
+    for prompt in ("Explain how to open a file in Python", "What is a Git repository?", "Compare video codecs"):
+        predicted, reason = _predict_toolsets_by_rules(prompt, AVAILABLE)
+        assert predicted == set(), (prompt, predicted, reason)
+
+
+def test_policy_uses_minimum_toolset_for_url_summary():
+    predicted, _ = _predict_toolsets_by_rules("Summarize https://example.com", AVAILABLE)
+    assert predicted == {"web"}
+
+
+def test_missing_classifier_confidence_is_unknown_not_perfect():
+    assert _extract_confidence({"toolsets": ["web"]}) is None

--- a/tests/test_recovery_schema_v2.py
+++ b/tests/test_recovery_schema_v2.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_recovery_schema_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_recovery_schema_test.tools import build_recovery_tool_schema
+
+
+def test_recovery_schema_accepts_multiple_live_validated_requests_without_stale_enum():
+    schema = build_recovery_tool_schema({"web", "synthetic"})
+    props = schema["parameters"]["properties"]
+    assert props["toolsets"]["items"] == {"type": "string"}
+    assert props["toolsets"]["minItems"] == 1
+    assert "toolset" not in props

--- a/tests/test_registry_adapter.py
+++ b/tests/test_registry_adapter.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_registry_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_registry_test.registry_adapter import RegistryAdapter
+
+
+class Entry:
+    def __init__(self, toolset):
+        self.toolset = toolset
+
+
+class Registry:
+    def get_registered_toolset_names(self):
+        return ["web", "synthetic"]
+
+    def get_tool_names_for_toolset(self, name):
+        return {"web": ["web_search"], "synthetic": ["synthetic_run"]}.get(name, [])
+
+    def get_entry(self, name):
+        return Entry("synthetic") if name == "synthetic_run" else None
+
+    def get_definitions(self, names, quiet=True):
+        return [{"type": "function", "function": {"name": name}} for name in sorted(names)]
+
+    def get_toolset_alias_target(self, name):
+        return "web" if name == "search" else None
+
+
+def test_registry_adapter_discovers_dynamic_toolsets_without_private_apis():
+    adapter = RegistryAdapter(Registry())
+    assert adapter.available_toolsets() == {"web", "synthetic"}
+    assert adapter.tools_for_toolset("synthetic") == {"synthetic_run"}
+    assert adapter.toolset_for_tool("synthetic_run") == "synthetic"
+    assert adapter.resolve_alias("search") == "web"

--- a/tests/test_smoke_hardening.py
+++ b/tests/test_smoke_hardening.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from smoke_hardening import (  # noqa: F401
     test_deterministic_routes,
+    test_first_turn_surface_is_sticky_and_does_not_shrink_or_reclassify,
+    test_late_pre_llm_compatibility_routes_before_request_without_explicit_agent,
     test_pre_llm_call_skips_after_core_hook_routed_turn,
     test_recovery_schema_and_core_hook_surface,
     test_request_toolset_git_expansion,
     test_request_toolset_unknown_suggestion,
+    test_tool_request_middleware_expands_registered_pruned_tool_before_validation,
 )

--- a/tests/test_state_v2.py
+++ b/tests/test_state_v2.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_state_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_state_test.state import RouterState
+
+
+def test_session_surface_can_only_expand():
+    state = RouterState()
+    state.set_initial_surface({"web"})
+    state.expand_surface({"browser"})
+    state.expand_surface({"web"})
+    assert state.active_toolsets == {"web", "browser"}
+    assert state.expansion_count == 1
+
+
+def test_initial_surface_is_applied_only_once():
+    state = RouterState()
+    assert state.set_initial_surface({"web"}) is True
+    assert state.set_initial_surface({"file"}) is False
+    assert state.active_toolsets == {"web"}
+
+
+def test_state_is_agent_scoped():
+    class Agent:
+        pass
+
+    from hermes_tool_router_state_test.state import _get_router_state
+
+    first, second = Agent(), Agent()
+    _get_router_state(first).set_initial_surface({"web"})
+    assert _get_router_state(second).active_toolsets == set()
+
+
+def test_agent_lookup_requires_session_when_multiple_agents_are_live():
+    class Agent:
+        pass
+
+    from hermes_tool_router_state_test.state import _drop_agent_ref, _get_agent_ref, _store_agent_ref
+
+    first, second = Agent(), Agent()
+    _store_agent_ref(first, "session-a")
+    _store_agent_ref(second, "session-b")
+    assert _get_agent_ref("session-a") is first
+    assert _get_agent_ref("session-b") is second
+    assert _get_agent_ref() is None
+    _drop_agent_ref("session-a")
+    assert _get_agent_ref("session-a") is None

--- a/tools.py
+++ b/tools.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import difflib
-import json
 import logging
 from typing import Any, Dict, List, Optional, Set
 
@@ -21,40 +19,41 @@ logger = logging.getLogger(__name__)
 RECOVERY_TOOL_NAME = "request_toolset"
 RECOVERY_TOOLSET = "router_recovery"
 RECOVERY_TOOLSET_CHOICES = sorted(TOOLSET_DESCRIPTIONS)
-RECOVERY_TOOL_SCHEMA: Dict[str, Any] = {
-    "description": (
-        "Request an additional toolset to recover when a required capability "
-        "was filtered out by token-router. Call this only when a needed tool "
-        "is missing from the current tool list."
-    ),
-    "parameters": {
-        "type": "object",
-        "additionalProperties": False,
-        "properties": {
-            "toolset": {
-                "type": "string",
-                "description": (
-                    "Add one Hermes toolset that is missing from the currently "
-                    "active set, usually because token-router pruning narrowed "
-                    "tools. Use exactly one toolset name per call."
-                ),
-                "enum": RECOVERY_TOOLSET_CHOICES,
-            },
-            "tool_name": {
-                "type": "string",
-                "description": (
-                    "Optional specific tool the model needs; the plugin will "
-                    "try to resolve its owning toolset."
-                ),
-            },
-            "reason": {
-                "type": "string",
-                "description": "Optional short rationale for logs/traceability.",
-                "maxLength": 200,
+
+
+def build_recovery_tool_schema(available_toolsets: Set[str]) -> Dict[str, Any]:
+    """Build the compact recovery schema from the live registry surface."""
+    return {
+        "description": "Load missing Hermes toolsets before continuing the task.",
+        "parameters": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "toolsets": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                    "uniqueItems": True,
+                    "description": (
+                        "One or more Hermes toolset names to add for this session, such as "
+                        "file, terminal, web, browser, computer_use, vision, image_gen, "
+                        "video, video_gen, memory, skills, session_search, cronjob, "
+                        "delegation, tts, or code_execution. Names are validated against "
+                        "the live registry when called."
+                    ),
+                },
+                "tool_name": {
+                    "type": "string",
+                    "description": "Optional registered tool whose owner toolset should be loaded.",
+                },
+                "reason": {"type": "string", "maxLength": 200},
             },
         },
-    },
-}
+    }
+
+
+# Import-time fallback; register() rebuilds this from the live registry.
+RECOVERY_TOOL_SCHEMA: Dict[str, Any] = build_recovery_tool_schema(set(RECOVERY_TOOLSET_CHOICES))
 def _resolve_toolset_to_tool_names(toolsets: Set[str]) -> Set[str]:
     """Resolve a set of toolset names to tool names via the registry."""
     tool_names: Set[str] = set()
@@ -156,11 +155,13 @@ def _detect_missing_toolset(
     except Exception:
         return None
 def _get_all_tool_names() -> Set[str]:
-    """Get ALL tool names from the registry."""
+    """Get all registered tool names through public toolset APIs."""
     try:
         from tools.registry import registry
-        entries = registry._snapshot_entries()
-        return {e.name for e in entries}
+        names: Set[str] = set()
+        for toolset in registry.get_registered_toolset_names():
+            names.update(registry.get_tool_names_for_toolset(toolset) or [])
+        return names
     except Exception:
         return set()
 def _cache_full_toolset(agent: Any) -> None:
@@ -294,6 +295,7 @@ def _expand_toolset(agent: Any, toolset_name: str) -> None:
 
         # Get current predicted toolsets
         state = _get_router_state(agent)
+        state.expand_surface({toolset_name})
         if state.predicted_toolsets is not None:
             state.predicted_toolsets.add(toolset_name)
         else:


### PR DESCRIPTION
## Summary

- upgrades the router to first-turn, session-sticky, monotonic routing
- uses stock `pre_llm_call` and `tool_request` middleware; no Hermes core patch required
- adds dynamic `request_toolset` recovery and explicit routing for core tool intents
- adds bounded optional classifier support with hard timeout and fail-open behavior
- adds packaging, CI, diagnostics, synthetic benchmarks, and live Edith A/B evaluation
- integrates the live evaluator with `hermes-autoresearch`

## Verification

- 39 pytest tests pass
- Ruff passes
- 500-record deterministic benchmark: 100% required recall and exact-set accuracy
- live Edith safe-core evaluation: 10/10 cases, 100% route recall, exact accuracy, tool success, and answer accuracy
- average first-provider-request reduction across paired no-tool, terminal, and web cases: 61.60%
- isolated wheel build/import and Hermes plugin entry point verified

## Compatibility

Current Hermes requires no source modifications. The plugin uses stock `pre_llm_call` for request-time narrowing and stock `tool_request` middleware for automatic recovery. An earlier core hook remains optional for reducing internal preflight work.

## Safety

The plugin remains disabled by default. Test on an alternate profile before enabling it on a primary profile.
