### PR TITLE
fix: filter unmaterialized tool names

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_tools_test"
+spec = importlib.util.spec_from_file_location(
+    PKG,
+    ROOT / "__init__.py",
+    submodule_search_locations=[str(ROOT)],
+)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_tools_test.tools import _resolve_toolset_to_tool_names
+
+
+class Registry:
+    def get_tool_names_for_toolset(self, name):
+        assert name == "terminal"
+        return ["close_terminal", "process", "read_terminal", "terminal"]
+
+    def get_definitions(self, names, quiet=True):
+        assert quiet is True
+        return [
+            {"type": "function", "function": {"name": name}}
+            for name in sorted(names & {"process", "terminal"})
+        ]
+
+
+def test_toolset_resolution_drops_names_without_definitions(monkeypatch):
+    registry_module = ModuleType("tools.registry")
+    registry_module.registry = Registry()
+    tools_package = ModuleType("tools")
+    tools_package.registry = registry_module
+    monkeypatch.setitem(sys.modules, "tools", tools_package)
+    monkeypatch.setitem(sys.modules, "tools.registry", registry_module)
+
+    assert _resolve_toolset_to_tool_names({"terminal"}) == {"process", "terminal"}

--- a/tools.py
+++ b/tools.py
@@ -84,7 +84,29 @@ def _resolve_toolset_to_tool_names(toolsets: Set[str]) -> Set[str]:
                 "%s: failed to resolve toolset '%s': %s",
                 PLUGIN_NAME, ts, exc,
             )
-    return tool_names
+
+    if not tool_names:
+        return tool_names
+
+    try:
+        definitions = registry.get_definitions(tool_names, quiet=True) or []
+        materialized_names = {
+            definition.get("function", {}).get("name", "")
+            for definition in definitions
+        }
+        materialized_names.discard("")
+        dropped_names = tool_names - materialized_names
+        if dropped_names:
+            logger.debug(
+                "%s: dropped %d unmaterialized tool name(s): %s",
+                PLUGIN_NAME,
+                len(dropped_names),
+                sorted(dropped_names)[:10],
+            )
+        return materialized_names
+    except Exception as exc:
+        logger.debug("%s: materialization filter skipped: %s", PLUGIN_NAME, exc)
+        return tool_names
 def _filter_tool_definitions(
     tool_defs: List[Dict[str, Any]],
     allowed_tool_names: Set[str],


### PR DESCRIPTION
Closes #3

Hermes 0.18.x can register terminal tool names that have no callable definitions, causing a missing-definition warning on every terminal-routed turn. Filter resolved names through the live definitions while preserving the original set if that lookup fails.

Regression coverage verifies that `close_terminal` and `read_terminal` are excluded while materialized terminal tools remain available. All 40 tests and Ruff checks pass.
