### PR TITLE
chore: migrate CI actions to Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install -e '.[dev,classifier]'


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v4 to the Node.js 24-native v6 line
- update `actions/setup-python` from v5 to the Node.js 24-native v6 line
- remove the Node.js 20 deprecation annotations from the test matrix

## Validation

- `python -m py_compile *.py tests/*.py benchmarks/*.py`
- `python -m pytest` — 40 passed
- `python -m ruff check .` — passed
- `python benchmarks/run.py` — perfect recall/precision, no critical misses
- `python -m build` — sdist and wheel built successfully
