### PR TITLE
fix: route inert period probes without classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Against the live 39-tool Hermes registry, Hermes's own rough request estimator m
 
 See [`docs/baselines/v0.2-rc1.md`](docs/baselines/v0.2-rc1.md) for commands and caveats. These are estimator results, not provider billing receipts.
 
-## Live Edith A/B validation
+## Live test-profile A/B validation
 
 A paired full-tools-versus-routed evaluation using `openai/gpt-5.4-mini` produced:
 

--- a/__init__.py
+++ b/__init__.py
@@ -263,7 +263,17 @@ def _route_tool_surface(source: str, agent: Any = None, **kwargs: Any) -> Option
     predicted: Optional[Set[str]]
     deterministic_enabled = bool(profile_cfg.get("deterministic_rules_enabled", True))
     rule_reason = "disabled"
-    if deterministic_enabled:
+    # Empty and period/ellipsis-only probes carry no actionable intent. Route
+    # them deterministically even on classifier-first profiles: asking a
+    # stochastic model to interpret "." can yield a low-confidence "all"
+    # response, and the safe fail-open then defeats the smallest-surface smoke
+    # test. Other symbols and emoji remain ambiguous and keep the normal
+    # classifier/fail-open path.
+    probe_chars = {char for char in user_message if not char.isspace()}
+    if not probe_chars or probe_chars <= {".", "…"}:
+        predicted = set()
+        rule_reason = "empty_or_period_probe"
+    elif deterministic_enabled:
         predicted, rule_reason = _predict_toolsets_by_rules(user_message, available)
     else:
         predicted = None

--- a/benchmarks/live_cases.json
+++ b/benchmarks/live_cases.json
@@ -15,10 +15,10 @@
   },
   {
     "id": "file",
-    "prompt": "Read /tmp/router-edith-probe.txt and return its exact contents only.",
+    "prompt": "Read /tmp/router-test-probe.txt and return its exact contents only.",
     "expected_toolsets": ["file"],
     "expected_tools": ["read_file"],
-    "must_contain": ["EDITH_ROUTER_PROBE_OK"]
+    "must_contain": ["ROUTER_TEST_PROBE_OK"]
   },
   {
     "id": "web",
@@ -43,7 +43,7 @@
   },
   {
     "id": "session_search",
-    "prompt": "Use session search to find the previous Edith session where Tampa weather was tested. Return its session ID only.",
+    "prompt": "Use session search to find the previous test-profile session where weather lookup was tested. Return its session ID only.",
     "expected_toolsets": ["session_search"],
     "expected_tools": ["session_search"],
     "must_contain": []

--- a/docs/live-evaluation-v0.2-rc1.md
+++ b/docs/live-evaluation-v0.2-rc1.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-11
 
-Profile: `edith` (isolated test profile)
+Profile: `router-test` (isolated test profile)
 
 Model: `openai/gpt-5.4-mini` through OpenRouter
 
@@ -22,7 +22,7 @@ An optional earlier hook could reduce internal preflight work, but it is not req
 
 ## Paired methodology
 
-The evaluator launches fresh Edith sessions with the same profile and prompt in two modes:
+The evaluator launches fresh test-profile sessions with the same profile and prompt in two modes:
 
 1. Router enabled.
 2. Router bypassed for that subprocess with `HERMES_TOKEN_ROUTER_ENABLED=false`.

--- a/docs/pre_turn_context_build_hook.md
+++ b/docs/pre_turn_context_build_hook.md
@@ -14,7 +14,7 @@ This hook would let plugins such as `hermes-token-router` adjust the active tool
 
 ## Motivation
 
-The Edith token-router currently needs to reduce tool schema bloat before the main LLM request is built. Today it does that with a plugin-side runtime wrapper around `build_turn_context`. The wrapper is intentionally fail-open and guarded by `inspect.signature`, but it still depends on Hermes internals:
+The test-profile token-router currently needs to reduce tool schema bloat before the main LLM request is built. Today it does that with a plugin-side runtime wrapper around `build_turn_context`. The wrapper is intentionally fail-open and guarded by `inspect.signature`, but it still depends on Hermes internals:
 
 - positional argument order in `build_turn_context`;
 - `summarize_user_message_for_log` being passed as a keyword argument;
@@ -92,7 +92,7 @@ For the first implementation, `None` is enough. It matches current hook style an
 
 ## Current Wrapper vs. Clean Hook
 
-Current experimental Edith shim:
+Current experimental test-profile shim:
 
 ```text
 plugin register()

--- a/scripts/live_router_evaluator.py
+++ b/scripts/live_router_evaluator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Paired live Edith evaluator for hermes-token-router."""
+"""Paired live test-profile evaluator for hermes-token-router."""
 
 from __future__ import annotations
 
@@ -21,10 +21,10 @@ FIRST_INPUT_RE = re.compile(r"API call #1:.*?\bin=(\d+)")
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--profile", default="edith")
+    parser.add_argument("--profile", default="router-test")
     parser.add_argument("--cases", type=Path, default=Path(__file__).resolve().parents[1] / "benchmarks/live_cases.json")
-    parser.add_argument("--state-db", type=Path, default=Path.home() / ".hermes/profiles/edith/state.db")
-    parser.add_argument("--agent-log", type=Path, default=Path.home() / ".hermes/profiles/edith/logs/agent.log")
+    parser.add_argument("--state-db", type=Path, default=Path.home() / ".hermes/profiles/router-test/state.db")
+    parser.add_argument("--agent-log", type=Path, default=Path.home() / ".hermes/profiles/router-test/logs/agent.log")
     parser.add_argument("--output", type=Path, default=Path(__file__).resolve().parents[1] / "runs/live_router_eval.json")
     parser.add_argument("--timeout", type=int, default=180)
     parser.add_argument("--baseline-cases", default="answer_only,terminal,web")
@@ -125,7 +125,7 @@ def main() -> int:
     if args.max_cases > 0:
         cases = cases[: args.max_cases]
     baseline_ids = {item.strip() for item in args.baseline_cases.split(",") if item.strip()}
-    Path("/tmp/router-edith-probe.txt").write_text("EDITH_ROUTER_PROBE_OK\n")
+    Path("/tmp/router-test-probe.txt").write_text("ROUTER_TEST_PROBE_OK\n")
 
     results: list[dict[str, Any]] = []
     for case in cases:
@@ -183,7 +183,7 @@ def main() -> int:
     payload = {
         "score": round(score, 6),
         "accepted": route_recall == 1.0 and tool_success >= 0.9 and answer_accuracy >= 0.9,
-        "reason": f"live Edith router evaluation: {sum(bool(r.get('case_passed')) for r in routed)}/{len(routed)} cases passed",
+        "reason": f"live test-profile router evaluation: {sum(bool(r.get('case_passed')) for r in routed)}/{len(routed)} cases passed",
         "metrics": metrics,
         "results": results,
     }

--- a/tests/smoke_hardening.py
+++ b/tests/smoke_hardening.py
@@ -214,6 +214,32 @@ def test_deterministic_routes():
         _assert_route(prompt, expected)
 
 
+def test_inert_period_probes_skip_classifier_without_capturing_symbols(monkeypatch):
+    monkeypatch.setitem(_TEST_CONFIG["global"], "deterministic_rules_enabled", False)
+    monkeypatch.setitem(
+        _TEST_CONFIG["global"],
+        "classifier",
+        {"enabled": True, "provider": "openrouter", "model": "fake-router"},
+    )
+
+    classified = []
+
+    def record_classifier(user_message, *args, **kwargs):
+        classified.append(user_message)
+        return None
+
+    monkeypatch.setattr(plugin, "_predict_toolsets_via_llm", record_classifier)
+    for prompt in (".", "...", "…", "   ", ". ."):
+        agent = _route(prompt)
+        assert _exposed_toolsets(agent) == {"request_toolset"}
+    assert classified == []
+
+    for prompt in ("?", "🖼️"):
+        agent = _route(prompt)
+        assert classified[-1] == prompt
+        assert "web" in _exposed_toolsets(agent)
+
+
 def test_late_pre_llm_compatibility_routes_before_request_without_explicit_agent():
     agent = _FakeAgent()
     agent._current_turn_id = "late-turn"

--- a/tests/test_config_v2.py
+++ b/tests/test_config_v2.py
@@ -41,9 +41,9 @@ def test_explicit_profile_is_respected(monkeypatch):
 def test_process_override_can_disable_router_for_ab_evaluation(monkeypatch):
     from hermes_tool_router_config_test.config import _is_router_active
 
-    monkeypatch.setenv("HERMES_PROFILE", "edith")
+    monkeypatch.setenv("HERMES_PROFILE", "router-test")
     monkeypatch.setenv("HERMES_TOKEN_ROUTER_ENABLED", "false")
-    assert _is_router_active({"profiles": {"edith": {"enabled": True}}}) is False
+    assert _is_router_active({"profiles": {"router-test": {"enabled": True}}}) is False
 
 
 def test_classifier_is_opt_in():

--- a/tests/test_smoke_hardening.py
+++ b/tests/test_smoke_hardening.py
@@ -7,6 +7,7 @@ from smoke_hardening import (  # noqa: F401
     test_first_turn_surface_is_sticky_and_does_not_shrink_or_reclassify,
     test_late_pre_llm_compatibility_routes_before_request_without_explicit_agent,
     test_pre_llm_call_skips_after_core_hook_routed_turn,
+    test_inert_period_probes_skip_classifier_without_capturing_symbols,
     test_recovery_schema_and_core_hook_surface,
     test_request_toolset_git_expansion,
     test_request_toolset_unknown_suggestion,


### PR DESCRIPTION
## Summary

- route whitespace and period/ellipsis-only first-turn probes without calling the optional external classifier
- preserve normal classifier and fail-open behavior for meaningful non-alphanumeric input, including `?` and emoji
- add regression coverage for both the narrow bypass and the ambiguity boundary
- replace identifying test-profile names and probe markers with generic `router-test` / `test-profile` terminology

## Problem

Classifier-first configurations can receive inconsistent predictions for contentless probes such as `.`. A low-confidence `all` result correctly fails open, but that unnecessarily sends the full tool surface for a prompt with no actionable intent.

## Safety boundary

The deterministic bypass is intentionally limited to:

- whitespace-only input
- ASCII periods (`.`)
- the Unicode ellipsis (`…`)
- mixtures of those characters and whitespace

Other symbols and emoji continue through the configured classifier. Existing fail-open handling is unchanged.

## Verification

- [x] Full test suite: 41 passed
- [x] Focused probe-boundary regression passed
- [x] Python compilation passed
- [x] Ruff passed
- [x] 500-record benchmark: 100% required recall and 100% exact-set accuracy
- [x] Wheel build passed
- [x] `git diff --check` passed
- [x] Added-diff privacy and credential scan passed
- [x] Repository scan found no remaining identifying profile names in the branch head
- [x] Independent exact-commit review of the routing fix: PASS
