### PR TITLE
fix: enable reliable model-routed tool selection

### DIFF
--- a/policy.py
+++ b/policy.py
@@ -82,13 +82,14 @@ PLAIN_ANSWER_RE = re.compile(
 ROUTER_SYSTEM_PROMPT = """You are a tool-router classifier. Given a user message and a list of available toolsets with descriptions, predict which toolsets the AI assistant will need to respond.
 
 Rules:
-1. Return ONLY JSON: {"toolsets": ["name"], "confidence": 0.0}.
+1. Return ONLY JSON: {{"toolsets": ["name"], "confidence": 0.0}}.
 2. confidence must be a number from 0.0 to 1.0.
 3. Include ONLY toolsets directly relevant to the user's request.
 4. Do not include terminal, file, or web unless the request actually needs them.
 5. For ordinary questions that can be answered without tools, return an empty array.
 6. If the message is ambiguous or uncertain, return "all" as the only toolset.
 7. Be conservative; only include toolsets you are confident are needed.
+8. Personal calendar, itinerary, reservation, or flight-detail lookups require "skills" and "terminal" when those toolsets are available.
 Example response:
 {{"toolsets": ["terminal", "file"], "confidence": 0.96}}
 

--- a/tests/test_policy_v2.py
+++ b/tests/test_policy_v2.py
@@ -12,7 +12,11 @@ module = importlib.util.module_from_spec(spec)
 sys.modules[PKG] = module
 spec.loader.exec_module(module)
 
-from hermes_tool_router_policy_v2_test.policy import _extract_confidence, _predict_toolsets_by_rules
+from hermes_tool_router_policy_v2_test.policy import (
+    ROUTER_SYSTEM_PROMPT,
+    _extract_confidence,
+    _predict_toolsets_by_rules,
+)
 
 
 AVAILABLE = {"web", "browser", "file", "terminal", "vision", "image_gen", "video", "video_gen"}
@@ -31,3 +35,14 @@ def test_policy_uses_minimum_toolset_for_url_summary():
 
 def test_missing_classifier_confidence_is_unknown_not_perfect():
     assert _extract_confidence({"toolsets": ["web"]}) is None
+
+
+def test_classifier_prompt_formats_literal_json_contract():
+    prompt = ROUTER_SYSTEM_PROMPT.format(
+        toolset_descriptions="  - web: current web data",
+        user_message="What is the weather right now?",
+    )
+
+    assert 'Return ONLY JSON: {"toolsets": ["name"], "confidence": 0.0}.' in prompt
+    assert '{"toolsets": ["terminal", "file"], "confidence": 0.96}' in prompt
+    assert 'Personal calendar, itinerary, reservation, or flight-detail lookups require "skills" and "terminal"' in prompt


### PR DESCRIPTION
## Summary

- Escape the classifier prompt's literal JSON contract so Python `str.format()` no longer raises `KeyError` before the model request.
- Add explicit routing guidance for personal calendar, itinerary, reservation, and flight-detail lookups to use `skills` and `terminal` when available.
- Add a regression test that formats the real classifier prompt and verifies both requirements.
- Replace identifying test-profile names and probe markers with generic `router-test` / `test-profile` terminology.

## Verification

- 41 pytest tests passed.
- Python compilation and standalone hardening smoke passed.
- Ruff passed.
- 500-prompt benchmark: 100% exact-set accuracy, recall, and precision; zero critical misses.
- Wheel built and imported successfully on Python 3.11.
- Committed-tree privacy, secrets, local-identifier, artifact, and whitespace gates passed.
- Repository scan found no remaining identifying profile names in the branch head.

## Scope

The functional change remains limited to `policy.py` and `tests/test_policy_v2.py`. The additional documentation, evaluator, benchmark, and test-fixture edits anonymize the public test profile. Draft PR #6 received the same anonymization cleanup.
