### PR TITLE
fix: fail open when recovery registration is incomplete

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -126,6 +126,22 @@ except ImportError:  # pragma: no cover - direct loader fallback
 
 logger = logging.getLogger(__name__)
 
+# Registration is checked at plugin startup. If a Hermes update removes either
+# recovery mechanism, routing must fail open rather than leave a narrowed
+# surface that cannot reliably add a missed capability.
+_registration_checked = False
+_recovery_middleware_registered = False
+_recovery_tool_registered = False
+
+
+def _recovery_is_ready() -> bool:
+    """Return whether a registered runtime can safely narrow tool schemas."""
+    # Direct-import test harnesses do not call register(); preserve their
+    # isolated behavior. A real plugin runtime always marks registration.
+    if not _registration_checked:
+        return True
+    return _recovery_middleware_registered and _recovery_tool_registered
+
 
 def _mark_turn_routed(agent: Any, state: RouterState, turn_id: str, source: str) -> None:
     """Record that this agent/turn already passed through the router."""
@@ -179,6 +195,16 @@ def _route_tool_surface(source: str, agent: Any = None, **kwargs: Any) -> Option
 
     turn_id = kwargs.get("turn_id") or getattr(agent, "_current_turn_id", "") or ""
     state = _get_router_state(agent)
+
+    if not _recovery_is_ready():
+        _restore_full_tools(agent)
+        state.active = False
+        state.predicted_toolsets = None
+        logger.warning(
+            "%s: recovery registration incomplete; keeping full tool surface",
+            PLUGIN_NAME,
+        )
+        return None
 
     # Production policy: classify only the initial tool surface. Later turns
     # reuse the session-sticky surface so tool schemas remain cache-stable.
@@ -495,6 +521,11 @@ def register(ctx) -> None:
       - post_tool_call         : best-effort expansion after executed tool calls
     """
 
+    global _registration_checked, _recovery_middleware_registered, _recovery_tool_registered
+    _registration_checked = True
+    _recovery_middleware_registered = False
+    _recovery_tool_registered = False
+
     try:
         from hermes_cli.plugins import VALID_HOOKS
         if "pre_turn_context_build" in VALID_HOOKS:
@@ -507,6 +538,7 @@ def register(ctx) -> None:
     ctx.register_hook("on_session_end", on_session_end)
     try:
         ctx.register_middleware("tool_request", tool_request_middleware)
+        _recovery_middleware_registered = True
     except Exception as exc:
         logger.warning("%s: tool_request middleware unavailable: %s", PLUGIN_NAME, exc)
 
@@ -521,12 +553,15 @@ def register(ctx) -> None:
             description=recovery_schema["description"],
             emoji="",
         )
+        _recovery_tool_registered = True
     except Exception as exc:
         logger.warning("%s: failed to register recovery tool: %s", PLUGIN_NAME, exc)
 
     logger.info(
-        "%s plugin registered (routing: pre_llm_call compatibility; middleware: tool_request; tool: request_toolset)",
+        "%s plugin registered (routing: pre_llm_call compatibility; middleware: %s; tool: %s)",
         PLUGIN_NAME,
+        _recovery_middleware_registered,
+        _recovery_tool_registered,
     )
 
 

--- a/tests/smoke_hardening.py
+++ b/tests/smoke_hardening.py
@@ -194,6 +194,34 @@ def test_recovery_schema_and_core_hook_surface():
     assert callable(plugin.pre_llm_call)
 
 
+def test_incomplete_registered_recovery_fails_open():
+    names = (
+        "_registration_checked",
+        "_recovery_middleware_registered",
+        "_recovery_tool_registered",
+    )
+    original = {name: plugin.__dict__[name] for name in names}
+    try:
+        plugin.__dict__.update({
+            "_registration_checked": True,
+            "_recovery_middleware_registered": False,
+            "_recovery_tool_registered": True,
+        })
+        agent = _FakeAgent()
+        plugin.pre_turn_context_build(
+            agent=agent,
+            turn_id="recovery-missing",
+            user_message="latest weather today",
+            conversation_history=[],
+            is_first_turn=True,
+        )
+        assert "web_search" in agent.valid_tool_names
+        assert "read_file" in agent.valid_tool_names
+        assert "shell" in agent.valid_tool_names
+    finally:
+        plugin.__dict__.update(original)
+
+
 def test_deterministic_routes():
     cases = [
         ("what is photosynthesis", {"request_toolset"}),

--- a/tests/test_smoke_hardening.py
+++ b/tests/test_smoke_hardening.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from smoke_hardening import (  # noqa: F401
     test_deterministic_routes,
     test_first_turn_surface_is_sticky_and_does_not_shrink_or_reclassify,
+    test_incomplete_registered_recovery_fails_open,
     test_late_pre_llm_compatibility_routes_before_request_without_explicit_agent,
     test_pre_llm_call_skips_after_core_hook_routed_turn,
     test_inert_period_probes_skip_classifier_without_capturing_symbols,


### PR DESCRIPTION
## Problem

Tool-surface narrowing is safe only when the router has a working recovery path. The router depends on both of these runtime registrations:

- `tool_request` middleware, which can expand a pruned registered tool before dispatch;
- `request_toolset`, which provides explicit recovery for a capability the model needs later.

Before this change, registration failures were logged but narrowing could continue. If a Hermes API change or registration problem removed either recovery mechanism, the router could expose a narrowed surface without a reliable way to restore a missing capability.

## Reasoning

The router's intended safety behavior is fail-open. A missing recovery mechanism should therefore disable narrowing, not merely generate a warning while continuing into the unsafe path.

Registration status is known at plugin startup, so the router can make this decision deterministically. Direct-import test harnesses that do not call `register()` retain their existing isolated behavior; the fail-open gate applies once the real plugin runtime has performed registration.

## Solution

- Track whether plugin registration has been checked.
- Record successful registration of `tool_request` middleware and `request_toolset` separately.
- Before narrowing, restore the full tool surface and deactivate routing if either recovery mechanism is unavailable.
- Include the actual middleware/tool registration status in the startup log.
- Add a regression smoke test covering incomplete recovery registration.

## Before / After

**Before:** Hermes reports a recovery registration failure, but the router may still narrow the tool surface. A later missing capability can leave the model without automatic or explicit recovery.

**After:** if either recovery mechanism fails to register, the router keeps the full tool surface and logs a clear warning. When both mechanisms register successfully, existing narrowing behavior is unchanged.

## Verification

- `python -m py_compile *.py tests/*.py benchmarks/*.py`
- `python -m pytest -q` — 41 passed
- `python benchmarks/run.py` — 500 records, 100% required recall, 100% exact-set accuracy, 0% full fallback
- `python -m build` — sdist and wheel built successfully
- `git diff --check` — passed

The repository's optional Ruff command remains non-clean on the upstream baseline due to pre-existing findings; Ruff is not part of the repository's GitHub Actions workflow. The new regression test does not add a warning to the affected lines.

---

**Disclosure:** This pull request was prepared by Daniel von Seckendorff with assistance from Hermes Agent (AI). The change was derived from a reproducible local Hermes plugin-registration compatibility failure; deployment-specific configuration and private fixtures were intentionally excluded. Please review the implementation and assumptions as a normal contributor submission.
