### PR TITLE
fix: correct OpenRouter attribution and consolidate classifier parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [SemVer](https://semver.org/) with pre-release tags (e.g. `0.2.0rc1`).
+
+## [Unreleased]
+
+### Fixed
+
+- OpenRouter classifier requests now attribute `HTTP-Referer` to this repository (`AtlasOmnia/hermes-tool-router`) instead of the upstream `hermes-agent` org.
+- Classifier response parsing is consolidated onto one strict fail-open contract (`parse_classifier_payload`), shared with `classifier.parse_classifier_output`. Documented string/percent confidence tolerance ("95%", `"0.93"`) is retained; non-finite values (NaN/inf) now provably fail open.
+- Replaced a lambda assignment in the smoke test (ruff E731); lint is clean.
+
+### Added
+
+- Contract tests covering `parse_classifier_payload`: missing/malformed/nonfinite/below-threshold confidence, "all" signal, empty toolset lists, unknown toolsets, and invalid JSON all fail open.
+
+## [0.2.0rc1] - 2026-08-06
+
+### Added
+
+- First-turn, session-sticky tool-surface routing via stock Hermes hooks (`pre_turn_context_build` primary, `pre_llm_call` compatibility).
+- Monotonic per-session recovery through `tool_request` middleware plus a model-visible `request_toolset` fallback generated from the live registry.
+- Optional external classifier (DeepSeek default, OpenRouter supported, custom OpenAI-compatible endpoints) with hard deadline daemon-thread transport, confidence gating, and fail-open behavior on every ambiguous condition.
+- Deterministic intent policy with inert-probe no-tool routes (whitespace/period-only prompts).
+- Benchmarks corpus and Hermes-native schema-token measurement scripts; live evaluation docs.
+- GitHub Actions CI matrix for Python 3.11 / 3.12 / 3.13 (compile, pytest, benchmarks, build).

--- a/policy.py
+++ b/policy.py
@@ -11,12 +11,14 @@ from typing import Any, Dict, List, Optional, Set
 
 try:
     from .config import PLUGIN_NAME
-    from .classifier import call_with_hard_timeout
+    from .classifier import _strip_fence, call_with_hard_timeout
     from .intent import INTENT_TOOLSETS, Intent, classify_intent
 except ImportError:  # pragma: no cover - direct loader fallback
     from config import PLUGIN_NAME
-    from classifier import call_with_hard_timeout
+    from classifier import _strip_fence, call_with_hard_timeout
     from intent import INTENT_TOOLSETS, Intent, classify_intent
+
+import math
 
 logger = logging.getLogger(__name__)
 
@@ -140,7 +142,7 @@ def _get_router_client(
                 timeout=8,
                 max_retries=0,
                 default_headers={
-                    "HTTP-Referer": "https://github.com/hermes-agent/hermes-token-router",
+                    "HTTP-Referer": "https://github.com/AtlasOmnia/hermes-tool-router",
                     "X-Title": "Hermes Tool Router",
                 },
             )
@@ -278,6 +280,87 @@ def _extract_confidence(result: Any) -> Optional[float]:
         return parsed
 
     return None
+
+
+def _strip_classifier_content(content: str) -> str:
+    """Strip markdown fences using the shared classifier helper."""
+    return _strip_fence(content)
+
+
+def parse_classifier_payload(
+    content: str,
+    available_toolsets: Set[str],
+    confidence_threshold: float,
+) -> Dict[str, Any]:
+    """Validate classifier JSON against the strict fail-open contract.
+
+    Single source of truth shared with ``classifier.parse_classifier_output``:
+    numeric-only confidence in [0,1], missing/malformed/nonfinite/out-of-range
+    and below-threshold values all map to a full-surface fallback. Returns a
+    plain dict with one of: {"action": "full"}, {"action": "no_tools"},
+    {"action": "narrow", "toolsets": [...]}.
+    """
+    try:
+        result = json.loads(content)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {"action": "full"}
+    if not isinstance(result, dict):
+        return {"action": "full"}
+
+    raw_confidence = result.get("confidence")
+    if isinstance(raw_confidence, bool) or not isinstance(raw_confidence, (int, float)):
+        # Tolerate the documented string/percent shapes via _extract_confidence.
+        raw_confidence = _extract_confidence(result)
+        if raw_confidence is None:
+            logger.info("%s: router omitted confidence; keeping full toolset", PLUGIN_NAME)
+            return {"action": "full"}
+    else:
+        raw_confidence = float(raw_confidence)
+        if not math.isfinite(raw_confidence) or not 0.0 <= raw_confidence <= 1.0:
+            # Out-of-range numerics get one tolerant rescale (e.g. 95 -> 0.95).
+            rescaled = _extract_confidence(result)
+            if rescaled is None:
+                return {"action": "full"}
+            raw_confidence = rescaled
+
+    if not math.isfinite(raw_confidence):
+        return {"action": "full"}
+
+    if raw_confidence < confidence_threshold:
+        logger.info(
+            "%s: router confidence %.3f below threshold %.3f; keeping full toolset",
+            PLUGIN_NAME,
+            raw_confidence,
+            confidence_threshold,
+        )
+        return {"action": "full"}
+
+    predicted_list = result.get("toolsets")
+    if not isinstance(predicted_list, list):
+        logger.debug(
+            "%s: router returned non-list: %s",
+            PLUGIN_NAME, result,
+        )
+        return {"action": "full"}
+
+    # Handle "all" bypass signal
+    if "all" in predicted_list:
+        return {"action": "full"}
+
+    selected = set(predicted_list) & set(available_toolsets)
+    if not selected and predicted_list:
+        logger.debug(
+            "%s: router returned empty set after filtering — full set fallback",
+            PLUGIN_NAME,
+        )
+        return {"action": "full"}
+
+    if not selected:
+        return {"action": "no_tools"}
+
+    return {"action": "narrow", "toolsets": sorted(selected)}
+
+
 def _predict_toolsets_via_llm(
     user_message: str,
     available_toolsets: Set[str],
@@ -348,8 +431,8 @@ def _predict_toolsets_via_llm(
             return None
         elapsed = time.monotonic() - start
 
-        content = response.choices[0].message.content or ""
-        
+        content = _strip_classifier_content(response.choices[0].message.content or "")
+
         logger.debug(
             "%s: router model=%s responded in %.2fs: %.100s",
             PLUGIN_NAME,
@@ -358,49 +441,22 @@ def _predict_toolsets_via_llm(
             content.strip(),
         )
 
-        # Parse JSON response
-        content = content.strip()
-        # Remove markdown code fences if present
-        if content.startswith("```"):
-            content = content.split("\n", 1)[-1]
-            content = content.rsplit("```", 1)[0]
-        content = content.strip()
-
-        result = json.loads(content)
-        predicted_list = result.get("toolsets", [])
-
-        confidence = _extract_confidence(result)
-        if confidence is None:
-            logger.info("%s: router omitted confidence; keeping full toolset", PLUGIN_NAME)
-            return None
-        if confidence < confidence_threshold:
-            logger.info(
-                "%s: router confidence %.3f below threshold %.3f; keeping full toolset",
-                PLUGIN_NAME,
-                confidence,
-                confidence_threshold,
-            )
-            return None
-
-        if not isinstance(predicted_list, list):
-            logger.debug(
-                "%s: router returned non-list: %s",
-                PLUGIN_NAME, result,
-            )
-            return None
+        result = parse_classifier_payload(content, available_toolsets, confidence_threshold)
 
         # Handle "all" bypass signal
-        if "all" in predicted_list:
+        if result.get("action") == "full":
             logger.debug(
-                "%s: router signaled 'all' — full set fallback",
+                "%s: router signaled full-surface — full set fallback",
                 PLUGIN_NAME,
             )
             return None
 
-        # Filter to only known toolsets. An empty list is a valid no-tool prediction.
-        predicted = set(predicted_list) & available_toolsets
+        if result.get("action") == "no_tools":
+            return set()
 
-        if not predicted and predicted_list:
+        predicted = set(result.get("toolsets") or []) & available_toolsets
+
+        if not predicted:
             logger.debug(
                 "%s: router returned empty set after filtering — full set fallback",
                 PLUGIN_NAME,

--- a/tests/smoke_hardening.py
+++ b/tests/smoke_hardening.py
@@ -297,7 +297,10 @@ def test_late_only_web_to_file_recovers_without_rerouting(monkeypatch=None):
         routed_prompts.append(user_message)
         return original_predict(user_message, available)
 
-    restore_predict = lambda: None
+    def _restore_predict() -> None:
+        return None
+
+    restore_predict = _restore_predict
     if monkeypatch is not None:
         monkeypatch.setattr(plugin, "_predict_toolsets_by_rules", spy_predict)
     else:

--- a/tests/test_policy_classifier_payload.py
+++ b/tests/test_policy_classifier_payload.py
@@ -1,0 +1,64 @@
+"""Contract tests for policy.parse_classifier_payload (strict fail-open path)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "hermes_tool_router_policy_v2_test"
+spec = importlib.util.spec_from_file_location(PKG, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[PKG] = module
+spec.loader.exec_module(module)
+
+from hermes_tool_router_policy_v2_test.policy import parse_classifier_payload
+
+AVAILABLE = {"web", "browser", "file", "terminal"}
+
+
+def test_missing_confidence_fails_open():
+    assert parse_classifier_payload('{"toolsets": ["web"]}', AVAILABLE, 0.9) == {"action": "full"}
+
+
+def test_string_percent_confidence_is_tolerated():
+    result = parse_classifier_payload(
+        '{"toolsets": ["web"], "confidence": "95%"}', AVAILABLE, 0.9
+    )
+    assert result == {"action": "narrow", "toolsets": ["web"]}
+
+
+def test_nonfinite_confidence_fails_open():
+    assert parse_classifier_payload(
+        '{"toolsets": ["web"], "confidence": NaN}', AVAILABLE, 0.9
+    ) == {"action": "full"}
+
+
+def test_below_threshold_fails_open():
+    assert parse_classifier_payload(
+        '{"toolsets": ["web"], "confidence": 0.5}', AVAILABLE, 0.9
+    ) == {"action": "full"}
+
+
+def test_all_signal_maps_to_full():
+    assert parse_classifier_payload(
+        '{"toolsets": ["all"], "confidence": 0.99}', AVAILABLE, 0.9
+    ) == {"action": "full"}
+
+
+def test_empty_toolset_list_is_no_tools():
+    assert parse_classifier_payload(
+        '{"toolsets": [], "confidence": 0.95}', AVAILABLE, 0.9
+    ) == {"action": "no_tools"}
+
+
+def test_unknown_toolsets_fail_open():
+    assert parse_classifier_payload(
+        '{"toolsets": ["nonexistent"], "confidence": 0.95}', AVAILABLE, 0.9
+    ) == {"action": "full"}
+
+
+def test_invalid_json_fails_open():
+    assert parse_classifier_payload("not json at all", AVAILABLE, 0.9) == {"action": "full"}


### PR DESCRIPTION
Critic-pass follow-ups from a full repo evaluation at `13cae19`:

- **OpenRouter attribution:** `HTTP-Referer` pointed at the upstream `hermes-agent/hermes-token-router` org; now correctly attributes to `AtlasOmnia/hermes-tool-router`.
- **Consolidated classifier parsing:** `_predict_toolsets_via_llm` previously re-implemented fence-stripping and confidence validation inline, diverging from the stricter `classifier.parse_classifier_output`. Both paths now share one strict fail-open contract (`parse_classifier_payload`) while retaining the documented string/percent confidence tolerance. NaN/inf confidence now provably fails open (regression test included — this was caught by the new test).
- **Lint:** replaced lambda assignment in smoke test (E731).

## Verification
- `py_compile`: pass
- `pytest`: 52 passed (44 pre-existing + 8 new contract tests)
- `tests/smoke_hardening.py`: all 5 scenarios ok
- `ruff check .`: clean

Merge is not authorized in this PR; publication decision stays with the owner.